### PR TITLE
fix vite dirname for esm

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
+import { fileURLToPath } from 'url'
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 // https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## Summary
- use `fileURLToPath` to define `__dirname` in `vite.config.js`

## Testing
- `pnpm install`
- `npm run lint` *(fails: 28 problems)*

------
https://chatgpt.com/codex/tasks/task_e_6842cc47c6c0832c9171a51862602b30