### PR TITLE
Add company selector for master in trips

### DIFF
--- a/frontend/src/pages/trips/Trips.jsx
+++ b/frontend/src/pages/trips/Trips.jsx
@@ -2,12 +2,15 @@ import React, { useState, useEffect } from 'react';
 import { Plus, Search, Edit, Trash2, MapPin, Calendar, Clock, Users, Car, User, DollarSign } from 'lucide-react';
 import api from '../../services/api';
 import { useToast } from '../../contexts/ToastContext';
+import { useAuth } from '../../contexts/AuthContext';
 
 const Trips = () => {
+  const { isMaster, user } = useAuth();
   const [trips, setTrips] = useState([]);
   const [vehicles, setVehicles] = useState([]);
   const [drivers, setDrivers] = useState([]);
   const [customers, setCustomers] = useState([]);
+  const [companies, setCompanies] = useState([]);
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState('');
   const [showModal, setShowModal] = useState(false);
@@ -26,6 +29,7 @@ const Trips = () => {
     maxPassengers: '',
     vehicleId: '',
     driverId: '',
+    companyId: '',
     status: 'PLANNED',
     observations: ''
   });
@@ -43,6 +47,9 @@ const Trips = () => {
     fetchVehicles();
     fetchDrivers();
     fetchCustomers();
+    if (isMaster()) {
+      fetchCompanies();
+    }
   }, []);
 
   const fetchTrips = async () => {
@@ -88,6 +95,15 @@ const Trips = () => {
     }
   };
 
+  const fetchCompanies = async () => {
+    try {
+      const response = await api.get('/companies');
+      setCompanies(response.data.companies || []);
+    } catch (error) {
+      console.error('Erro ao carregar empresas:', error);
+    }
+  };
+
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
@@ -98,6 +114,10 @@ const Trips = () => {
         price: parseFloat(formData.price) || 0,
         maxPassengers: parseInt(formData.maxPassengers) || 0
       };
+      if (isMaster()) {
+        submitData.company_id = formData.companyId;
+      }
+      delete submitData.companyId;
 
       if (editingTrip) {
         await api.put(`/trips/${editingTrip.id}`, submitData);
@@ -133,6 +153,7 @@ const Trips = () => {
       maxPassengers: trip.maxPassengers || '',
       vehicleId: trip.vehicleId || '',
       driverId: trip.driverId || '',
+      companyId: trip.company_id || '',
       status: trip.status || 'PLANNED',
       observations: trip.observations || ''
     });
@@ -167,6 +188,7 @@ const Trips = () => {
       maxPassengers: '',
       vehicleId: '',
       driverId: '',
+      companyId: '',
       status: 'PLANNED',
       observations: ''
     });
@@ -452,6 +474,24 @@ const Trips = () => {
                 <div>
                   <h4 className="text-md font-medium text-gray-900 mb-3">Informações Básicas</h4>
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    {isMaster() && (
+                      <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">
+                          Empresa *
+                        </label>
+                        <select
+                          required
+                          value={formData.companyId}
+                          onChange={(e) => setFormData({ ...formData, companyId: e.target.value })}
+                          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-zapchat-primary focus:border-zapchat-primary"
+                        >
+                          <option value="">Selecione a empresa</option>
+                          {companies.map((c) => (
+                            <option key={c.id} value={c.id}>{c.name}</option>
+                          ))}
+                        </select>
+                      </div>
+                    )}
                     <div className="md:col-span-2">
                       <label className="block text-sm font-medium text-gray-700 mb-1">
                         Título do Passeio *


### PR DESCRIPTION
## Summary
- allow master users to choose a company when creating trips
- send selected company_id in create/update request

## Testing
- `npm test` in `backend` *(fails: jest not found)*
- `npm test` in `frontend` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6845962918a8832c9bf73ae2ffd0470f