### PR TITLE
Remove event and seller from sales

### DIFF
--- a/backend/src/middleware/saleValidations.js
+++ b/backend/src/middleware/saleValidations.js
@@ -94,10 +94,6 @@ const createSaleValidation = [
     .isLength({ max: 2000 })
     .withMessage('Notas internas devem ter no máximo 2000 caracteres'),
 
-  body('event_id')
-    .optional()
-    .isUUID()
-    .withMessage('ID do evento deve ser um UUID válido'),
 
   body('trip_id')
     .notEmpty()
@@ -250,10 +246,6 @@ const updateSaleValidation = [
     .isLength({ max: 2000 })
     .withMessage('Notas internas devem ter no máximo 2000 caracteres'),
 
-  body('event_id')
-    .optional()
-    .isUUID()
-    .withMessage('ID do evento deve ser um UUID válido'),
   body('trip_id')
     .optional()
     .isUUID()
@@ -301,10 +293,6 @@ const listSalesValidation = [
     .isUUID()
     .withMessage('ID do cliente deve ser um UUID válido'),
 
-  query('event_id')
-    .optional()
-    .isUUID()
-    .withMessage('ID do evento deve ser um UUID válido'),
 
   query('trip_id')
     .optional()
@@ -357,12 +345,6 @@ const getSalesByCustomerValidation = [
     .withMessage('ID do cliente deve ser um UUID válido')
 ];
 
-// Validações para busca por evento
-const getSalesByEventValidation = [
-  param('event_id')
-    .isUUID()
-    .withMessage('ID do evento deve ser um UUID válido')
-];
 
 module.exports = {
   createSaleValidation,
@@ -371,6 +353,6 @@ module.exports = {
   deleteSaleValidation,
   listSalesValidation,
   getSalesByCustomerValidation,
-  getSalesByEventValidation
+  
 };
 

--- a/backend/src/models/Sale.js
+++ b/backend/src/models/Sale.js
@@ -246,17 +246,6 @@ const Sale = sequelize.define('Sale', {
     comment: 'Veículo utilizado no passeio'
   },
 
-  seller_id: {
-    type: DataTypes.UUID,
-    allowNull: true,
-    references: {
-      model: 'sellers',
-      key: 'id'
-    },
-    onUpdate: 'CASCADE',
-    onDelete: 'SET NULL',
-    comment: 'Vendedor responsável pela venda'
-  },
 
   // Cliente responsável pela venda
   customer_id: {
@@ -271,15 +260,6 @@ const Sale = sequelize.define('Sale', {
     comment: 'Cliente responsável pela venda'
   },
   
-  event_id: {
-    type: DataTypes.UUID,
-    allowNull: true,
-    references: {
-      model: 'events',
-      key: 'id'
-    },
-    comment: 'Evento relacionado à venda (opcional)'
-  },
   
   company_id: {
     type: DataTypes.UUID,
@@ -314,9 +294,6 @@ const Sale = sequelize.define('Sale', {
       fields: ['customer_id']
     },
     {
-      fields: ['event_id']
-    },
-    {
       fields: ['created_by']
     },
     {
@@ -339,9 +316,6 @@ const Sale = sequelize.define('Sale', {
     },
     {
       fields: ['vehicle_id']
-    },
-    {
-      fields: ['seller_id']
     },
     {
       fields: ['company_id', 'status']

--- a/backend/src/routes/sales.js
+++ b/backend/src/routes/sales.js
@@ -9,8 +9,7 @@ const {
   getSaleValidation,
   deleteSaleValidation,
   listSalesValidation,
-  getSalesByCustomerValidation,
-  getSalesByEventValidation
+  getSalesByCustomerValidation
 } = require('../middleware/saleValidations');
 
 // Middleware para verificar erros de validação
@@ -46,12 +45,6 @@ router.get('/customer/:customer_id',
   SaleController.byCustomer
 );
 
-// GET /api/sales/event/:event_id - Buscar vendas por evento
-router.get('/event/:event_id',
-  getSalesByEventValidation,
-  checkValidationErrors,
-  SaleController.byEvent
-);
 
 // GET /api/sales/:id - Buscar venda específica
 router.get('/:id',


### PR DESCRIPTION
## Summary
- drop `event_id` and `seller_id` fields from Sale model
- clean up sale controller and validations
- remove `/event/:event_id` endpoint

## Testing
- `npm test` *(fails: Seller Routes)*

------
https://chatgpt.com/codex/tasks/task_e_684896ba52e4832cb0f34c47e1b2a74e