### PR TITLE
Add seller association to Sales model

### DIFF
--- a/backend/src/database/migrations/add_seller_id_to_sales.js
+++ b/backend/src/database/migrations/add_seller_id_to_sales.js
@@ -1,0 +1,25 @@
+const { sequelize } = require('../../config/database');
+const { DataTypes } = require('sequelize');
+
+module.exports = {
+  up: async () => {
+    const queryInterface = sequelize.getQueryInterface();
+    await queryInterface.addColumn('sales', 'seller_id', {
+      type: DataTypes.UUID,
+      allowNull: false,
+      references: {
+        model: 'users',
+        key: 'id'
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'RESTRICT'
+    });
+    await queryInterface.addIndex('sales', ['seller_id']);
+  },
+
+  down: async () => {
+    const queryInterface = sequelize.getQueryInterface();
+    await queryInterface.removeIndex('sales', ['seller_id']);
+    await queryInterface.removeColumn('sales', 'seller_id');
+  }
+};

--- a/backend/src/models/Sale.js
+++ b/backend/src/models/Sale.js
@@ -270,6 +270,18 @@ const Sale = sequelize.define('Sale', {
     },
     comment: 'Empresa responsável pela venda'
   },
+
+  seller_id: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    references: {
+      model: 'users',
+      key: 'id'
+    },
+    onUpdate: 'CASCADE',
+    onDelete: 'RESTRICT',
+    comment: 'Usuário vendedor da venda'
+  },
   
   created_by: {
     type: DataTypes.UUID,
@@ -316,6 +328,9 @@ const Sale = sequelize.define('Sale', {
     },
     {
       fields: ['vehicle_id']
+    },
+    {
+      fields: ['seller_id']
     },
     {
       fields: ['company_id', 'status']

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -56,6 +56,10 @@ User.hasMany(Sale, {
   foreignKey: 'created_by',
   as: 'created_sales'
 });
+User.hasMany(Sale, {
+  foreignKey: 'seller_id',
+  as: 'sales_as_seller'
+});
 
 
 // Vehicle associations
@@ -158,6 +162,11 @@ Sale.belongsTo(Vehicle, {
   as: 'vehicle'
 });
 
+
+Sale.belongsTo(User, {
+  foreignKey: 'seller_id',
+  as: 'seller'
+});
 
 Sale.belongsTo(User, {
   foreignKey: 'created_by',


### PR DESCRIPTION
## Summary
- add `seller_id` field to `Sale` model
- index the new `seller_id` field
- relate Sales to Users via `seller_id`
- expose seller-based sales from `User` model
- create migration to add the seller reference

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849cf8666c0832cae7b3ae9e298a6c6