### PR TITLE
Add seller support to SaleController

### DIFF
--- a/backend/src/controllers/SaleController.js
+++ b/backend/src/controllers/SaleController.js
@@ -83,6 +83,12 @@ class SaleController {
             required: false
           },
           {
+            model: User,
+            as: 'seller',
+            attributes: ['id', 'first_name', 'last_name', 'email'],
+            required: false
+          },
+          {
             model: Company,
             as: 'company',
             attributes: ['id', 'name']
@@ -177,6 +183,12 @@ class SaleController {
             as: 'users',
             attributes: ['id', 'first_name', 'email']
           }
+          ,{
+            model: User,
+            as: 'seller',
+            attributes: ['id', 'first_name', 'last_name', 'email'],
+            required: false
+          }
         ]
       });
 
@@ -210,6 +222,20 @@ class SaleController {
         company_id: user.company_id,
         created_by: user.id
       };
+
+      // Validar se o vendedor informado é válido
+      if (saleData.seller_id) {
+        const seller = await User.findOne({ where: { id: saleData.seller_id } });
+        if (
+          !seller ||
+          (user.role !== 'master' && seller.company_id !== user.company_id)
+        ) {
+          return res.status(400).json({
+            success: false,
+            message: 'Vendedor não encontrado ou não pertence à sua empresa'
+          });
+        }
+      }
 
       // Validar se o cliente pertence à mesma empresa
       const customer = await Customer.findOne({
@@ -287,6 +313,12 @@ class SaleController {
             model: User,
             as: 'users',
             attributes: ['id', 'first_name', 'email']
+          }
+          ,{
+            model: User,
+            as: 'seller',
+            attributes: ['id', 'first_name', 'last_name', 'email'],
+            required: false
           }
         ]
       });
@@ -381,6 +413,19 @@ class SaleController {
         }
       }
 
+      if (req.body.seller_id && req.body.seller_id !== sale.seller_id) {
+        const seller = await User.findOne({ where: { id: req.body.seller_id } });
+        if (
+          !seller ||
+          (user.role !== 'master' && seller.company_id !== user.company_id)
+        ) {
+          return res.status(400).json({
+            success: false,
+            message: 'Vendedor não encontrado ou não pertence à sua empresa'
+          });
+        }
+      }
+
       await sale.update(req.body);
 
       // Buscar venda atualizada com relacionamentos
@@ -405,6 +450,12 @@ class SaleController {
             model: User,
             as: 'users',
             attributes: ['id', 'first_name', 'email']
+          }
+          ,{
+            model: User,
+            as: 'seller',
+            attributes: ['id', 'first_name', 'last_name', 'email'],
+            required: false
           }
         ]
       });

--- a/backend/src/models/Sale.js
+++ b/backend/src/models/Sale.js
@@ -246,6 +246,18 @@ const Sale = sequelize.define('Sale', {
     comment: 'Veículo utilizado no passeio'
   },
 
+  seller_id: {
+    type: DataTypes.UUID,
+    allowNull: true,
+    references: {
+      model: 'users',
+      key: 'id'
+    },
+    onUpdate: 'CASCADE',
+    onDelete: 'SET NULL',
+    comment: 'Usuário vendedor responsável pela venda'
+  },
+
 
   // Cliente responsável pela venda
   customer_id: {
@@ -316,6 +328,9 @@ const Sale = sequelize.define('Sale', {
     },
     {
       fields: ['vehicle_id']
+    },
+    {
+      fields: ['seller_id']
     },
     {
       fields: ['company_id', 'status']

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -57,6 +57,11 @@ User.hasMany(Sale, {
   as: 'created_sales'
 });
 
+User.hasMany(Sale, {
+  foreignKey: 'seller_id',
+  as: 'sales_as_seller'
+});
+
 
 // Vehicle associations
 Vehicle.belongsTo(Company, {
@@ -162,6 +167,11 @@ Sale.belongsTo(Vehicle, {
 Sale.belongsTo(User, {
   foreignKey: 'created_by',
   as: 'users'
+});
+
+Sale.belongsTo(User, {
+  foreignKey: 'seller_id',
+  as: 'seller'
 });
 
 // Relacionamento N:N entre Sale e Customer através de SaleCustomer


### PR DESCRIPTION
## Summary
- include seller in sale queries
- validate seller belongs to company
- add `seller_id` column and associations for Sale model

## Testing
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849cf880bc0832c9513718e182c2802