### PR TITLE
Update Dockerfile to use pnpm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,20 +6,21 @@ FROM node:18-alpine AS base
 WORKDIR /app
 
 # Copiar arquivos de configuração
-COPY client/package*.json ./
+COPY frontend/package.json ./
+COPY frontend/pnpm-lock.yaml ./
 
-# Instalar dependências
-RUN npm ci
+# Instalar pnpm e dependências
+RUN npm install -g pnpm && pnpm install --frozen-lockfile
 
 # Estágio de build
 FROM base AS build
 WORKDIR /app
 
 # Copiar todo o código fonte
-COPY client/ ./
+COPY frontend/ ./
 
 # Construir a aplicação
-RUN npm run build
+RUN pnpm run build
 
 # Estágio de produção
 FROM nginx:alpine AS production


### PR DESCRIPTION
## Summary
- switch frontend path from `client` to `frontend`
- install `pnpm` and use lockfile
- build using `pnpm run build`

## Testing
- `npm test` *(fails: jest not found)*
- `pnpm lint` *(fails: missing dependencies)*
- `pnpm install --frozen-lockfile` *(fails: lockfile outdated)*

------
https://chatgpt.com/codex/tasks/task_e_684b26cb3f7c832cb60e2a7db4886861