### PR TITLE
Add sale customer modal

### DIFF
--- a/backend/src/middleware/saleValidations.js
+++ b/backend/src/middleware/saleValidations.js
@@ -384,6 +384,44 @@ const getSalesByCustomerValidation = [
     .withMessage('ID do cliente deve ser um UUID válido')
 ];
 
+// Validação para adicionar cliente em venda
+const addSaleCustomerValidation = [
+  param('id')
+    .isUUID()
+    .withMessage('ID da venda deve ser um UUID válido'),
+  body('firstName')
+    .notEmpty()
+    .withMessage('Nome é obrigatório')
+    .isLength({ min: 2, max: 50 })
+    .withMessage('Nome deve ter entre 2 e 50 caracteres'),
+  body('lastName')
+    .notEmpty()
+    .withMessage('Sobrenome é obrigatório')
+    .isLength({ min: 2, max: 50 })
+    .withMessage('Sobrenome deve ter entre 2 e 50 caracteres'),
+  body('email')
+    .notEmpty()
+    .withMessage('Email é obrigatório')
+    .isEmail()
+    .withMessage('Email deve ser válido'),
+  body('phone')
+    .notEmpty()
+    .withMessage('Telefone é obrigatório')
+    .isLength({ min: 10, max: 20 })
+    .withMessage('Telefone deve ter entre 10 e 20 caracteres'),
+  body('birthDate')
+    .optional()
+    .isISO8601()
+    .withMessage('Data de nascimento inválida'),
+];
+
+// Validação para listagem de clientes da venda
+const listSaleCustomersValidation = [
+  param('id')
+    .isUUID()
+    .withMessage('ID da venda deve ser um UUID válido'),
+];
+
 
 module.exports = {
   createSaleValidation,
@@ -392,6 +430,8 @@ module.exports = {
   deleteSaleValidation,
   listSalesValidation,
   getSalesByCustomerValidation,
-  
+  addSaleCustomerValidation,
+  listSaleCustomersValidation,
+
 };
 

--- a/backend/src/routes/sales.js
+++ b/backend/src/routes/sales.js
@@ -9,7 +9,9 @@ const {
   getSaleValidation,
   deleteSaleValidation,
   listSalesValidation,
-  getSalesByCustomerValidation
+  getSalesByCustomerValidation,
+  addSaleCustomerValidation,
+  listSaleCustomersValidation
 } = require('../middleware/saleValidations');
 
 // Middleware para verificar erros de validação
@@ -51,6 +53,20 @@ router.get('/:id',
   getSaleValidation,
   checkValidationErrors,
   SaleController.show
+);
+
+// GET /api/sales/:id/customers - Listar clientes da venda
+router.get('/:id/customers',
+  listSaleCustomersValidation,
+  checkValidationErrors,
+  SaleController.listCustomers
+);
+
+// POST /api/sales/:id/customers - Adicionar cliente à venda
+router.post('/:id/customers',
+  addSaleCustomerValidation,
+  checkValidationErrors,
+  SaleController.addCustomer
 );
 
 // POST /api/sales - Criar nova venda

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -271,6 +271,12 @@ export const tripService = {
   updateStatus: (id, data) => api.patch(`/trips/${id}/status`, data),
 };
 
+// Serviços de vendas
+export const saleService = {
+  getCustomers: (saleId) => api.get(`/sales/${saleId}/customers`),
+  addCustomer: (saleId, data) => api.post(`/sales/${saleId}/customers`, data),
+};
+
 // Serviços de reservas
 export const bookingService = {
   getAll: (params) => api.get('/bookings', { params }),


### PR DESCRIPTION
## Summary
- enable adding customers to sales via API and frontend
- expose endpoints and validations for sale customers
- add customer management modal on sales page
- update API services

## Testing
- `npm test` *(fails: jest not found)*
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684b54fec924832c9ae1e88b8c4051f2