### PR TITLE
Allow creating customer during sale creation

### DIFF
--- a/backend/src/controllers/SaleController.js
+++ b/backend/src/controllers/SaleController.js
@@ -237,18 +237,32 @@ class SaleController {
         }
       }
 
-      // Validar se o cliente pertence à mesma empresa
-      const customer = await Customer.findOne({
-        where: {
-          id: saleData.customer_id,
-          company_id: user.company_id
-        }
-      });
+      let customer;
+      if (saleData.customer_id) {
+        customer = await Customer.findOne({
+          where: {
+            id: saleData.customer_id,
+            company_id: user.company_id
+          }
+        });
 
-      if (!customer) {
+        if (!customer) {
+          return res.status(400).json({
+            success: false,
+            message: 'Cliente não encontrado ou não pertence à sua empresa'
+          });
+        }
+      } else if (req.body.new_customer) {
+        const newCustomerData = {
+          ...req.body.new_customer,
+          company_id: user.company_id
+        };
+        customer = await Customer.create(newCustomerData);
+        saleData.customer_id = customer.id;
+      } else {
         return res.status(400).json({
           success: false,
-          message: 'Cliente não encontrado ou não pertence à sua empresa'
+          message: 'Cliente não informado'
         });
       }
 

--- a/backend/src/middleware/saleValidations.js
+++ b/backend/src/middleware/saleValidations.js
@@ -3,11 +3,49 @@ const { User } = require('../models');
 
 // Validações para criação de venda
 const createSaleValidation = [
+  body().custom((_, { req }) => {
+    if (!req.body.customer_id && !req.body.new_customer) {
+      throw new Error('ID do cliente é obrigatório');
+    }
+    return true;
+  }),
   body('customer_id')
-    .notEmpty()
-    .withMessage('ID do cliente é obrigatório')
+    .optional()
     .isUUID()
     .withMessage('ID do cliente deve ser um UUID válido'),
+  body('new_customer')
+    .optional()
+    .isObject()
+    .withMessage('Dados do novo cliente inválidos'),
+  body('new_customer.firstName')
+    .if(body('new_customer').exists())
+    .notEmpty()
+    .withMessage('Nome é obrigatório')
+    .isLength({ min: 2, max: 50 })
+    .withMessage('Nome deve ter entre 2 e 50 caracteres'),
+  body('new_customer.lastName')
+    .if(body('new_customer').exists())
+    .notEmpty()
+    .withMessage('Sobrenome é obrigatório')
+    .isLength({ min: 2, max: 50 })
+    .withMessage('Sobrenome deve ter entre 2 e 50 caracteres'),
+  body('new_customer.email')
+    .if(body('new_customer').exists())
+    .notEmpty()
+    .withMessage('Email é obrigatório')
+    .isEmail()
+    .withMessage('Email deve ser válido'),
+  body('new_customer.phone')
+    .if(body('new_customer').exists())
+    .notEmpty()
+    .withMessage('Telefone é obrigatório')
+    .isLength({ min: 10, max: 20 })
+    .withMessage('Telefone deve ter entre 10 e 20 caracteres'),
+  body('new_customer.birthDate')
+    .if(body('new_customer').exists())
+    .optional()
+    .isISO8601()
+    .withMessage('Data de nascimento inválida'),
 
   body('description')
     .optional()

--- a/frontend/src/pages/sales/Sales.jsx
+++ b/frontend/src/pages/sales/Sales.jsx
@@ -58,6 +58,14 @@ const Sales = () => {
     phone: '',
     birthDate: ''
   });
+  const [isNewMainCustomer, setIsNewMainCustomer] = useState(false);
+  const [newMainCustomer, setNewMainCustomer] = useState({
+    firstName: '',
+    lastName: '',
+    email: '',
+    phone: '',
+    birthDate: ''
+  });
 
   const [formData, setFormData] = useState({
     trip_id: '',
@@ -223,6 +231,11 @@ const Sales = () => {
     e.preventDefault();
     try {
       const dataToSend = { ...formData };
+
+      if (isNewMainCustomer) {
+        dataToSend.new_customer = { ...newMainCustomer };
+        delete dataToSend.customer_id;
+      }
       
       // Calcular total_amount
       const subtotal = parseFloat(dataToSend.subtotal) || 0;
@@ -292,6 +305,8 @@ const Sales = () => {
   const openModal = (mode, sale = null) => {
     setModalMode(mode);
     setSelectedSale(sale);
+    setIsNewMainCustomer(false);
+    setNewMainCustomer({ firstName: '', lastName: '', email: '', phone: '', birthDate: '' });
     
     if (mode === 'create') {
       resetForm();
@@ -352,6 +367,8 @@ const Sales = () => {
       notes: '',
       internal_notes: ''
     });
+    setIsNewMainCustomer(false);
+    setNewMainCustomer({ firstName: '', lastName: '', email: '', phone: '', birthDate: '' });
   };
 
   const formatCurrency = (value) => {
@@ -813,9 +830,17 @@ const Sales = () => {
                     Cliente Responsável *
                   </label>
                   <select
-                    value={formData.customer_id}
-                    onChange={(e) => setFormData({ ...formData, customer_id: e.target.value })}
-                    required
+                    value={isNewMainCustomer ? 'new' : formData.customer_id}
+                    onChange={(e) => {
+                      if (e.target.value === 'new') {
+                        setIsNewMainCustomer(true);
+                        setFormData({ ...formData, customer_id: '' });
+                      } else {
+                        setIsNewMainCustomer(false);
+                        setFormData({ ...formData, customer_id: e.target.value });
+                      }
+                    }}
+                    required={!isNewMainCustomer}
                     disabled={modalMode === 'view'}
                     className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-zapchat-primary focus:border-transparent disabled:bg-gray-100"
                   >
@@ -825,8 +850,63 @@ const Sales = () => {
                         {customer.firstName} {customer.lastName}
                       </option>
                     ))}
+                    <option value="new">Cadastrar novo cliente</option>
                   </select>
                 </div>
+
+                {isNewMainCustomer && (
+                  <div className="md:col-span-2 grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">Nome</label>
+                      <input
+                        type="text"
+                        value={newMainCustomer.firstName}
+                        onChange={(e) => setNewMainCustomer({ ...newMainCustomer, firstName: e.target.value })}
+                        required
+                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-zapchat-primary focus:border-zapchat-primary"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">Sobrenome</label>
+                      <input
+                        type="text"
+                        value={newMainCustomer.lastName}
+                        onChange={(e) => setNewMainCustomer({ ...newMainCustomer, lastName: e.target.value })}
+                        required
+                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-zapchat-primary focus:border-zapchat-primary"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
+                      <input
+                        type="email"
+                        value={newMainCustomer.email}
+                        onChange={(e) => setNewMainCustomer({ ...newMainCustomer, email: e.target.value })}
+                        required
+                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-zapchat-primary focus:border-zapchat-primary"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">Telefone</label>
+                      <input
+                        type="tel"
+                        value={newMainCustomer.phone}
+                        onChange={(e) => setNewMainCustomer({ ...newMainCustomer, phone: e.target.value })}
+                        required
+                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-zapchat-primary focus:border-zapchat-primary"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">Data de Nascimento</label>
+                      <input
+                        type="date"
+                        value={newMainCustomer.birthDate}
+                        onChange={(e) => setNewMainCustomer({ ...newMainCustomer, birthDate: e.target.value })}
+                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-zapchat-primary focus:border-zapchat-primary"
+                      />
+                    </div>
+                  </div>
+                )}
 
                 {modalMode !== 'create' && (
                   <div className="md:col-span-2">


### PR DESCRIPTION
## Summary
- add validations for optional new_customer fields when creating a sale
- auto-create customer in `SaleController` when new_customer data is sent
- extend sales page with option to create a new customer inside the sale modal

## Testing
- `npm test --prefix backend`
- `npm install --prefix frontend` *(no tests)*

------
https://chatgpt.com/codex/tasks/task_e_684b58e0c18c832ca7d9b2e437a694b4