### PR TITLE
Add dashboard stats API and fetch on UI

### DIFF
--- a/backend/src/controllers/DashboardController.js
+++ b/backend/src/controllers/DashboardController.js
@@ -1,0 +1,46 @@
+const { Company, User, Vehicle, Driver, Customer, Trip, Booking } = require('../models');
+
+class DashboardController {
+  static async getStats(req, res, next) {
+    try {
+      const companyFilter = req.user.isMaster() ? {} : { company_id: req.user.company_id };
+      const companyCondition = req.user.isMaster() ? {} : { id: req.user.company_id };
+
+      const [companies, users, vehicles, drivers, customers, trips, bookings, revenue] = await Promise.all([
+        Company.count(companyCondition),
+        User.count({ where: companyFilter }),
+        Vehicle.count({ where: companyFilter }),
+        Driver.count({ where: companyFilter }),
+        Customer.count({ where: companyFilter }),
+        Trip.count({ where: companyFilter }),
+        Booking.count({
+          include: [{ model: Trip, as: 'trip', where: companyFilter, required: true }]
+        }),
+        Booking.sum('total_amount', {
+          where: { status: 'pago' },
+          include: [{ model: Trip, as: 'trip', where: companyFilter, required: true }]
+        })
+      ]);
+
+      res.status(200).json({
+        success: true,
+        data: {
+          stats: {
+            companies: req.user.isMaster() ? companies : 1,
+            users,
+            vehicles,
+            drivers,
+            customers,
+            trips,
+            bookings,
+            revenue: parseFloat(revenue) || 0
+          }
+        }
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+}
+
+module.exports = DashboardController;

--- a/backend/src/routes/dashboard.js
+++ b/backend/src/routes/dashboard.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const router = express.Router();
+const DashboardController = require('../controllers/DashboardController');
+const { authenticate } = require('../middleware/auth');
+
+router.use(authenticate);
+
+router.get('/stats', DashboardController.getStats);
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -20,6 +20,7 @@ const customerRoutes = require('./routes/customers');
 const tripRoutes = require('./routes/trips');
 const bookingRoutes = require('./routes/bookings');
 const saleRoutes = require('./routes/sales');
+const dashboardRoutes = require('./routes/dashboard');
 
 const app = express();
 const PORT = process.env.PORT || 3001;
@@ -72,6 +73,7 @@ app.use('/api/customers', customerRoutes);
 app.use('/api/trips', tripRoutes);
 app.use('/api/bookings', bookingRoutes);
 app.use('/api/sales', saleRoutes);
+app.use('/api/dashboard', dashboardRoutes);
 
 // Middleware de tratamento de erros
 app.use(notFound);

--- a/frontend/src/pages/dashboard/Dashboard.jsx
+++ b/frontend/src/pages/dashboard/Dashboard.jsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
+import { useToast } from '../../contexts/ToastContext';
+import { dashboardService } from '../../services/api';
 import {
   Building2,
   Users,
@@ -26,24 +28,24 @@ const Dashboard = () => {
     revenue: 0,
   });
   const [loading, setLoading] = useState(true);
+  const { showError } = useToast();
 
   useEffect(() => {
-    // Simular carregamento de estatísticas
-    // Em uma implementação real, isso viria da API
-    setTimeout(() => {
-      setStats({
-        companies: isMaster() ? 12 : 1,
-        users: 45,
-        vehicles: 28,
-        drivers: 35,
-        customers: 156,
-        trips: 89,
-        bookings: 234,
-        revenue: 45670.50,
-      });
-      setLoading(false);
-    }, 1000);
-  }, [isMaster]);
+    const fetchStats = async () => {
+      setLoading(true);
+      try {
+        const response = await dashboardService.getStats();
+        setStats(response.data.stats);
+      } catch (err) {
+        console.error(err);
+        showError('Erro ao carregar estatísticas');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchStats();
+  }, [isMaster, showError]);
 
   const StatCard = ({ title, value, icon: Icon, color, trend }) => (
     <div className="bg-white rounded-lg shadow p-6">

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -289,4 +289,8 @@ export const bookingService = {
   getRevenue: (params) => api.get('/bookings/revenue', { params }),
 };
 
+export const dashboardService = {
+  getStats: () => api.get('/dashboard/stats'),
+};
+
 export default api;


### PR DESCRIPTION
## Summary
- add DashboardController with stats aggregation
- create dashboard route and mount it
- expose `dashboardService` on the frontend
- load real stats in dashboard pages with API errors handled

## Testing
- `npm test --prefix backend`
- `npm run lint --prefix frontend` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ec84d9e5c832cadef69b4d5d939bf