### PR TITLE
Add stats endpoints to services

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -245,6 +245,7 @@ export const driverService = {
   updateStatus: (id, status) => api.patch(`/drivers/${id}/status`, { status }),
   getActive: (params) => api.get('/drivers/active', { params }),
   getExpiringLicenses: (params) => api.get('/drivers/expiring-licenses', { params }),
+  getStats: (params) => api.get('/drivers/stats', { params }),
 };
 
 // Serviços de clientes
@@ -275,6 +276,7 @@ export const tripService = {
 export const saleService = {
   getCustomers: (saleId) => api.get(`/sales/${saleId}/customers`),
   addCustomer: (saleId, data) => api.post(`/sales/${saleId}/customers`, data),
+  getStats: (params) => api.get('/sales/stats', { params }),
 };
 
 // Serviços de reservas


### PR DESCRIPTION
## Summary
- expose `/drivers/stats` endpoint on `driverService`
- expose `/sales/stats` endpoint on `saleService`

## Testing
- `pnpm lint` *(fails: react-refresh/only-export-components and other errors)*
- `npm test` in backend

------
https://chatgpt.com/codex/tasks/task_e_684ec8566d7c832ca2402c936d3f9084