### PR TITLE
Add recent activity API and dashboard integration

### DIFF
--- a/backend/src/controllers/ActivityController.js
+++ b/backend/src/controllers/ActivityController.js
@@ -1,0 +1,101 @@
+const { Vehicle, Booking, Customer, Trip } = require('../models');
+const { Op } = require('sequelize');
+
+class ActivityController {
+  static async getRecent(req, res, next) {
+    try {
+      const { limit = 10, days = 7 } = req.query;
+      const sinceDate = new Date();
+      sinceDate.setDate(sinceDate.getDate() - parseInt(days));
+
+      let targetCompanyId;
+      if (req.user.isMaster() && req.user.company_id) {
+        targetCompanyId = req.user.company_id;
+      } else {
+        targetCompanyId = req.user.company_id;
+      }
+
+      const vehicles = await Vehicle.findAll({
+        where: {
+          company_id: targetCompanyId,
+          createdAt: { [Op.gte]: sinceDate }
+        },
+        order: [['createdAt', 'DESC']],
+        limit: parseInt(limit)
+      });
+
+      const bookings = await Booking.findAll({
+        where: {
+          createdAt: { [Op.gte]: sinceDate }
+        },
+        include: [
+          {
+            model: Trip,
+            as: 'Trip',
+            where: { company_id: targetCompanyId },
+            attributes: ['title'],
+            required: true
+          },
+          {
+            model: Customer,
+            as: 'Customer',
+            attributes: ['firstName', 'lastName']
+          }
+        ],
+        order: [['createdAt', 'DESC']],
+        limit: parseInt(limit)
+      });
+
+      const customers = await Customer.findAll({
+        where: {
+          company_id: targetCompanyId,
+          createdAt: { [Op.gte]: sinceDate }
+        },
+        order: [['createdAt', 'DESC']],
+        limit: parseInt(limit)
+      });
+
+      let activities = [];
+
+      vehicles.forEach(v => {
+        activities.push({
+          id: v.id,
+          type: 'vehicle',
+          message: `Novo veículo cadastrado: ${v.getFullName()}`,
+          createdAt: v.createdAt
+        });
+      });
+
+      bookings.forEach(b => {
+        const customerName = b.Customer ? `${b.Customer.firstName} ${b.Customer.lastName}` : '';
+        activities.push({
+          id: b.id,
+          type: 'booking',
+          message: `Nova reserva para ${b.Trip.title} - ${customerName}`,
+          createdAt: b.createdAt
+        });
+      });
+
+      customers.forEach(c => {
+        activities.push({
+          id: c.id,
+          type: 'customer',
+          message: `Novo cliente cadastrado: ${c.firstName} ${c.lastName}`,
+          createdAt: c.createdAt
+        });
+      });
+
+      activities.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+      activities = activities.slice(0, parseInt(limit));
+
+      res.status(200).json({
+        success: true,
+        data: { activities }
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+}
+
+module.exports = ActivityController;

--- a/backend/src/routes/activities.js
+++ b/backend/src/routes/activities.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const router = express.Router();
+const ActivityController = require('../controllers/ActivityController');
+const { authenticate } = require('../middleware/auth');
+
+router.use(authenticate);
+
+router.get('/recent', ActivityController.getRecent);
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -20,6 +20,7 @@ const customerRoutes = require('./routes/customers');
 const tripRoutes = require('./routes/trips');
 const bookingRoutes = require('./routes/bookings');
 const saleRoutes = require('./routes/sales');
+const activityRoutes = require('./routes/activities');
 
 const app = express();
 const PORT = process.env.PORT || 3001;
@@ -72,6 +73,7 @@ app.use('/api/customers', customerRoutes);
 app.use('/api/trips', tripRoutes);
 app.use('/api/bookings', bookingRoutes);
 app.use('/api/sales', saleRoutes);
+app.use('/api/activities', activityRoutes);
 
 // Middleware de tratamento de erros
 app.use(notFound);

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -289,4 +289,9 @@ export const bookingService = {
   getRevenue: (params) => api.get('/bookings/revenue', { params }),
 };
 
+// Serviços de atividades
+export const activityService = {
+  getRecent: (params) => api.get('/activities/recent', { params }),
+};
+
 export default api;


### PR DESCRIPTION
## Summary
- back-end: add ActivityController and /activities route
- server.js registers new route for recent activity
- front-end: add activityService to API helpers
- fetch recent activities in ModernDashboard and show relative times

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_684ec8574378832cb4ef7165d6915fbe