### PR TITLE
Fix duplicate seller_id field

### DIFF
--- a/backend/src/models/Sale.js
+++ b/backend/src/models/Sale.js
@@ -246,18 +246,6 @@ const Sale = sequelize.define('Sale', {
     comment: 'Veículo utilizado no passeio'
   },
 
-  seller_id: {
-    type: DataTypes.UUID,
-    allowNull: true,
-    references: {
-      model: 'users',
-      key: 'id'
-    },
-    onUpdate: 'CASCADE',
-    onDelete: 'SET NULL',
-    comment: 'Usuário vendedor responsável pela venda'
-  },
-
 
   // Cliente responsável pela venda
   customer_id: {


### PR DESCRIPTION
## Summary
- remove duplicate `seller_id` field in Sale model to avoid conflicting definitions

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851a23f9650832c9ec3ad3183a676c7