### PR TITLE
Improve sale details UI

### DIFF
--- a/frontend/src/pages/sales/SaleDetailsDrawer.jsx
+++ b/frontend/src/pages/sales/SaleDetailsDrawer.jsx
@@ -1,0 +1,195 @@
+import React from 'react';
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerFooter,
+  DrawerClose,
+} from '@/components/ui/drawer';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+} from '@/components/ui/card';
+import { FileText, CreditCard, Calendar, Users, User } from 'lucide-react';
+
+const formatCurrency = (value) =>
+  new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(
+    value || 0
+  );
+const formatDate = (dateString) =>
+  dateString ? new Date(dateString).toLocaleDateString('pt-BR') : '-';
+
+const SaleDetailsDrawer = ({ open, onOpenChange, sale, customers = [] }) => {
+  if (!sale) return null;
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange} direction="right">
+      <DrawerContent className="w-full sm:max-w-lg p-0">
+        <DrawerHeader className="border-b px-6 py-4">
+          <DrawerTitle>Detalhes da Venda</DrawerTitle>
+        </DrawerHeader>
+        <div className="p-6 space-y-4 overflow-y-auto max-h-[calc(100vh-140px)]">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <FileText className="w-4 h-4" /> Venda {sale.sale_number}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm">
+              <div>
+                <span className="font-semibold">Cliente Responsável:</span>{' '}
+                {sale.customer?.first_name} {sale.customer?.last_name}
+              </div>
+              {sale.seller && (
+                <div>
+                  <span className="font-semibold">Vendedor:</span>{' '}
+                  {sale.seller.first_name} {sale.seller.last_name}
+                </div>
+              )}
+              {sale.trip && (
+                <div>
+                  <span className="font-semibold">Passeio:</span> {sale.trip.title}
+                </div>
+              )}
+              {sale.vehicle && (
+                <div>
+                  <span className="font-semibold">Veículo:</span>{' '}
+                  {sale.vehicle.plate} - {sale.vehicle.model}
+                </div>
+              )}
+              {sale.driver && (
+                <div>
+                  <span className="font-semibold">Motorista:</span>{' '}
+                  {sale.driver.first_name} {sale.driver.last_name}
+                </div>
+              )}
+              {sale.description && (
+                <div>
+                  <span className="font-semibold">Descrição:</span>{' '}
+                  {sale.description}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <CreditCard className="w-4 h-4" /> Valores
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm">
+              <div>
+                <span className="font-semibold">Subtotal:</span>{' '}
+                {formatCurrency(sale.subtotal)}
+              </div>
+              <div>
+                <span className="font-semibold">Desconto:</span>{' '}
+                {sale.discount_percentage ? `${sale.discount_percentage}% ` : ''}
+                {formatCurrency(sale.discount_amount)}
+              </div>
+              <div>
+                <span className="font-semibold">Impostos:</span>{' '}
+                {formatCurrency(sale.tax_amount)}
+              </div>
+              <div>
+                <span className="font-semibold">Total:</span>{' '}
+                {formatCurrency(sale.total_amount)}
+              </div>
+              {sale.commission_percentage && (
+                <div>
+                  <span className="font-semibold">Comissão:</span>{' '}
+                  {sale.commission_percentage}% (
+                  {formatCurrency(sale.commission_amount)})
+                </div>
+              )}
+              {sale.payment_method && (
+                <div>
+                  <span className="font-semibold">Método de Pagamento:</span>{' '}
+                  {sale.payment_method}
+                </div>
+              )}
+              <div>
+                <span className="font-semibold">Status do Pagamento:</span>{' '}
+                {sale.payment_status}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Calendar className="w-4 h-4" /> Datas
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm">
+              <div>
+                <span className="font-semibold">Data da Venda:</span>{' '}
+                {formatDate(sale.sale_date)}
+              </div>
+              <div>
+                <span className="font-semibold">Vencimento:</span>{' '}
+                {formatDate(sale.due_date)}
+              </div>
+              <div>
+                <span className="font-semibold">Data do Pagamento:</span>{' '}
+                {formatDate(sale.payment_date)}
+              </div>
+              <div>
+                <span className="font-semibold">Data de Entrega:</span>{' '}
+                {formatDate(sale.delivery_date)}
+              </div>
+            </CardContent>
+          </Card>
+
+          {customers.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Users className="w-4 h-4" /> Participantes ({customers.length})
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2 text-sm">
+                {customers.map((sc) => (
+                  <div key={sc.id} className="flex items-center gap-2">
+                    <User className="w-4 h-4 text-zapchat-primary" />
+                    <span>
+                      {sc.customer.first_name} {sc.customer.last_name}
+                    </span>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+          )}
+
+          {sale.notes && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Observações</CardTitle>
+              </CardHeader>
+              <CardContent className="text-sm">{sale.notes}</CardContent>
+            </Card>
+          )}
+
+          {sale.internal_notes && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Notas Internas</CardTitle>
+              </CardHeader>
+              <CardContent className="text-sm">{sale.internal_notes}</CardContent>
+            </Card>
+          )}
+        </div>
+        <DrawerFooter className="border-t px-6 py-4">
+          <DrawerClose className="px-4 py-2 bg-zapchat-primary text-white rounded-md hover:bg-zapchat-medium">
+            Fechar
+          </DrawerClose>
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
+  );
+};
+
+export default SaleDetailsDrawer;

--- a/frontend/src/pages/sales/Sales.jsx
+++ b/frontend/src/pages/sales/Sales.jsx
@@ -3,6 +3,7 @@ import AuthContext from '@/contexts/AuthContext';
 import { useToast } from '../../contexts/ToastContext';
 import api from '../../services/api';
 import AsyncSelect from "react-select/async";
+import SaleDetailsDrawer from './SaleDetailsDrawer';
 import {
   DollarSign,
   Plus,
@@ -865,58 +866,12 @@ const Sales = () => {
       )}
 
       {/* Modal de Detalhes da Venda */}
-      {showDetailsModal && selectedSale && (
-        <div className="fixed inset-0 z-50 overflow-y-auto">
-          <div className="flex items-center justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-            <div className="fixed inset-0 transition-opacity" aria-hidden="true">
-              <div className="absolute inset-0 bg-gray-500 opacity-75"></div>
-            </div>
-            <span className="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
-            <div className="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
-              <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
-                <div className="flex justify-between items-center pb-4 mb-4 border-b border-gray-200">
-                  <h3 className="text-lg leading-6 font-medium text-gray-900">Detalhes da Venda</h3>
-                  <button onClick={() => setShowDetailsModal(false)} className="text-gray-400 hover:text-gray-500">
-                    <X className="h-6 w-6" />
-                  </button>
-                </div>
-                <div className="space-y-4 text-sm">
-                  <div><span className="font-semibold">Venda:</span> {selectedSale.sale_number}</div>
-                  <div><span className="font-semibold">Cliente Responsável:</span> {selectedSale.customer?.first_name} {selectedSale.customer?.last_name}</div>
-                  <div><span className="font-semibold">Vendedor:</span> {selectedSale.seller?.first_name} {selectedSale.seller?.last_name}</div>
-                  {selectedSale.trip && (<div><span className="font-semibold">Passeio:</span> {selectedSale.trip.title}</div>)}
-                  {selectedSale.vehicle && (<div><span className="font-semibold">Veículo:</span> {selectedSale.vehicle.plate} - {selectedSale.vehicle.model}</div>)}
-                  {selectedSale.driver && (<div><span className="font-semibold">Motorista:</span> {selectedSale.driver.first_name} {selectedSale.driver.last_name}</div>)}
-                  {selectedSale.description && (<div><span className="font-semibold">Descrição:</span> {selectedSale.description}</div>)}
-                  <div><span className="font-semibold">Subtotal:</span> {formatCurrency(selectedSale.subtotal)}</div>
-                  <div><span className="font-semibold">Desconto:</span> {selectedSale.discount_percentage ? `${selectedSale.discount_percentage}% ` : ''}{formatCurrency(selectedSale.discount_amount)}</div>
-                  <div><span className="font-semibold">Impostos:</span> {formatCurrency(selectedSale.tax_amount)}</div>
-                  <div><span className="font-semibold">Total:</span> {formatCurrency(selectedSale.total_amount)}</div>
-                  {selectedSale.commission_percentage && (<div><span className="font-semibold">Comissão:</span> {selectedSale.commission_percentage}% ({formatCurrency(selectedSale.commission_amount)})</div>)}
-                  {selectedSale.payment_method && (<div><span className="font-semibold">Método de Pagamento:</span> {selectedSale.payment_method}</div>)}
-                  <div><span className="font-semibold">Status do Pagamento:</span> {selectedSale.payment_status}</div>
-                  <div><span className="font-semibold">Data da Venda:</span> {formatDate(selectedSale.sale_date)}</div>
-                  <div><span className="font-semibold">Vencimento:</span> {formatDate(selectedSale.due_date)}</div>
-                  <div><span className="font-semibold">Data do Pagamento:</span> {formatDate(selectedSale.payment_date)}</div>
-                  <div><span className="font-semibold">Data de Entrega:</span> {formatDate(selectedSale.delivery_date)}</div>
-                  {saleCustomers.length > 0 && (
-                    <div>
-                      <span className="font-semibold">Participantes:</span>
-                      <ul className="list-disc list-inside">
-                        {saleCustomers.map(sc => (
-                          <li key={sc.id}>{sc.customer.first_name} {sc.customer.last_name}</li>
-                        ))}
-                      </ul>
-                    </div>
-                  )}
-                  {selectedSale.notes && (<div><span className="font-semibold">Observações:</span> {selectedSale.notes}</div>)}
-                  {selectedSale.internal_notes && (<div><span className="font-semibold">Notas Internas:</span> {selectedSale.internal_notes}</div>)}
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
+      <SaleDetailsDrawer
+        open={showDetailsModal && !!selectedSale}
+        onOpenChange={setShowDetailsModal}
+        sale={selectedSale}
+        customers={saleCustomers}
+      />
 
       {/* Modal de Venda */}
       {showModal && (


### PR DESCRIPTION
## Summary
- implement `SaleDetailsDrawer` component using drawer and card UI
- replace static sale detail modal with new interactive drawer

## Testing
- `npm test` in `backend`
- `pnpm run lint` *(fails: refreshError defined but never used and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6851ad0eee5c832c8e4e06e19ac25ded