### PR TITLE
Add sale payments model and migrations

### DIFF
--- a/backend/src/database/migrations/create_sale_payments.js
+++ b/backend/src/database/migrations/create_sale_payments.js
@@ -1,0 +1,55 @@
+const { sequelize } = require('../../config/database');
+const { DataTypes } = require('sequelize');
+
+module.exports = {
+  up: async () => {
+    const queryInterface = sequelize.getQueryInterface();
+    await queryInterface.createTable('sale_payments', {
+      id: {
+        type: DataTypes.UUID,
+        primaryKey: true,
+        defaultValue: DataTypes.UUIDV4
+      },
+      sale_id: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        references: { model: 'sales', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      amount: {
+        type: DataTypes.DECIMAL(10, 2),
+        allowNull: false
+      },
+      payment_method: {
+        type: DataTypes.ENUM('dinheiro', 'cartao_credito', 'cartao_debito', 'pix', 'transferencia', 'boleto', 'cheque', 'outro'),
+        allowNull: false
+      },
+      payment_date: {
+        type: DataTypes.DATEONLY,
+        allowNull: false
+      },
+      notes: {
+        type: DataTypes.TEXT,
+        allowNull: true
+      },
+      created_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: sequelize.literal('CURRENT_TIMESTAMP')
+      },
+      updated_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: sequelize.literal('CURRENT_TIMESTAMP')
+      }
+    });
+    await queryInterface.addIndex('sale_payments', ['sale_id']);
+    await queryInterface.addIndex('sale_payments', ['payment_method']);
+  },
+
+  down: async () => {
+    const queryInterface = sequelize.getQueryInterface();
+    await queryInterface.dropTable('sale_payments');
+  }
+};

--- a/backend/src/models/SalePayment.js
+++ b/backend/src/models/SalePayment.js
@@ -1,0 +1,44 @@
+const { DataTypes } = require('sequelize');
+const { sequelize } = require('../config/database');
+
+const SalePayment = sequelize.define('SalePayment', {
+  id: {
+    type: DataTypes.UUID,
+    defaultValue: DataTypes.UUIDV4,
+    primaryKey: true
+  },
+  sale_id: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    references: {
+      model: 'sales',
+      key: 'id'
+    },
+    onUpdate: 'CASCADE',
+    onDelete: 'CASCADE'
+  },
+  amount: {
+    type: DataTypes.DECIMAL(10, 2),
+    allowNull: false
+  },
+  payment_method: {
+    type: DataTypes.ENUM('dinheiro', 'cartao_credito', 'cartao_debito', 'pix', 'transferencia', 'boleto', 'cheque', 'outro'),
+    allowNull: false
+  },
+  payment_date: {
+    type: DataTypes.DATEONLY,
+    allowNull: false
+  },
+  notes: {
+    type: DataTypes.TEXT,
+    allowNull: true
+  }
+}, {
+  tableName: 'sale_payments',
+  indexes: [
+    { fields: ['sale_id'] },
+    { fields: ['payment_method'] }
+  ]
+});
+
+module.exports = SalePayment;

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -10,6 +10,7 @@ const Trip = require('./Trip');
 const Booking = require('./Booking');
 const Sale = require('./Sale');
 const SaleCustomer = require('./SaleCustomer');
+const SalePayment = require('./SalePayment');
 
 // Definir associações
 // Company associations
@@ -221,6 +222,16 @@ Vehicle.hasMany(Sale, {
   as: 'sales'
 });
 
+Sale.hasMany(SalePayment, {
+  foreignKey: 'sale_id',
+  as: 'payments'
+});
+
+SalePayment.belongsTo(Sale, {
+  foreignKey: 'sale_id',
+  as: 'sale'
+});
+
 
 module.exports = {
   sequelize,
@@ -232,6 +243,7 @@ module.exports = {
   Trip,
   Booking,
   Sale,
-  SaleCustomer
+  SaleCustomer,
+  SalePayment
 };
 

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -85,6 +85,7 @@ app.use(errorHandler);
 async function startServer() {
   try {
     await initializeDatabase();
+    await runMigrations();
 
     const server = app.listen(PORT, '0.0.0.0', () => {
       console.log(`🚀 Servidor rodando na porta ${PORT}`);


### PR DESCRIPTION
## Summary
- add SalePayment model
- create migration for sale_payments table
- register SalePayment in models index with Sale associations
- run migrations on server start

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853406e5380832c8257ffb5f0bb6677