### PR TITLE
Implement sale payment management

### DIFF
--- a/backend/src/controllers/SalePaymentController.js
+++ b/backend/src/controllers/SalePaymentController.js
@@ -1,0 +1,80 @@
+const { Sale, SalePayment } = require('../models');
+const { validationResult } = require('express-validator');
+
+class SalePaymentController {
+  static async index(req, res) {
+    try {
+      const { id } = req.params;
+      const sale = await Sale.findByPk(id, {
+        include: [{ model: SalePayment, as: 'payments' }]
+      });
+      if (!sale) {
+        return res.status(404).json({ success: false, message: 'Venda não encontrada' });
+      }
+      if (!req.user.isMaster() && sale.company_id !== req.user.company_id) {
+        return res.status(403).json({ success: false, message: 'Acesso negado' });
+      }
+      return res.json({ success: true, data: { payments: sale.payments } });
+    } catch (error) {
+      console.error('Erro ao listar pagamentos:', error);
+      return res.status(500).json({ success: false, message: 'Erro interno do servidor', error: error.message });
+    }
+  }
+
+  static async store(req, res) {
+    try {
+      const errors = validationResult(req);
+      if (!errors.isEmpty()) {
+        return res.status(400).json({ success: false, message: 'Dados inválidos', errors: errors.array() });
+      }
+      const { id } = req.params;
+      const { amount, payment_method, payment_date, notes } = req.body;
+      const sale = await Sale.findByPk(id, { include: [{ model: SalePayment, as: 'payments' }] });
+      if (!sale) {
+        return res.status(404).json({ success: false, message: 'Venda não encontrada' });
+      }
+      if (!req.user.isMaster() && sale.company_id !== req.user.company_id) {
+        return res.status(403).json({ success: false, message: 'Acesso negado' });
+      }
+      const totalPaid = sale.payments.reduce((acc, p) => acc + parseFloat(p.amount), 0);
+      if (totalPaid + parseFloat(amount) > parseFloat(sale.total_amount)) {
+        return res.status(400).json({ success: false, message: 'Valor pago excede o total da venda' });
+      }
+      const payment = await SalePayment.create({
+        sale_id: id,
+        amount,
+        payment_method,
+        payment_date,
+        notes
+      });
+      return res.status(201).json({ success: true, data: { payment } });
+    } catch (error) {
+      console.error('Erro ao registrar pagamento:', error);
+      return res.status(500).json({ success: false, message: 'Erro interno do servidor', error: error.message });
+    }
+  }
+
+  static async destroy(req, res) {
+    try {
+      const { id, payment_id } = req.params;
+      const payment = await SalePayment.findByPk(payment_id);
+      if (!payment || payment.sale_id !== id) {
+        return res.status(404).json({ success: false, message: 'Pagamento não encontrado' });
+      }
+      const sale = await Sale.findByPk(payment.sale_id);
+      if (!sale) {
+        return res.status(404).json({ success: false, message: 'Venda não encontrada' });
+      }
+      if (!req.user.isMaster() && sale.company_id !== req.user.company_id) {
+        return res.status(403).json({ success: false, message: 'Acesso negado' });
+      }
+      await payment.destroy();
+      return res.json({ success: true, message: 'Pagamento removido com sucesso' });
+    } catch (error) {
+      console.error('Erro ao remover pagamento:', error);
+      return res.status(500).json({ success: false, message: 'Erro interno do servidor', error: error.message });
+    }
+  }
+}
+
+module.exports = SalePaymentController;

--- a/backend/src/middleware/paymentValidations.js
+++ b/backend/src/middleware/paymentValidations.js
@@ -1,0 +1,39 @@
+const { body, param } = require('express-validator');
+
+const methods = [
+  'dinheiro',
+  'cartao_credito',
+  'cartao_debito',
+  'pix',
+  'transferencia',
+  'boleto',
+  'cheque',
+  'outro'
+];
+
+const paymentValidations = {
+  list: [
+    param('id').isUUID().withMessage('ID da venda deve ser um UUID válido')
+  ],
+  create: [
+    param('id').isUUID().withMessage('ID da venda deve ser um UUID válido'),
+    body('amount')
+      .notEmpty().withMessage('Valor é obrigatório')
+      .isFloat({ gt: 0 }).withMessage('Valor deve ser positivo'),
+    body('payment_method')
+      .notEmpty().withMessage('Método é obrigatório')
+      .isIn(methods).withMessage('Método de pagamento inválido'),
+    body('payment_date')
+      .optional()
+      .isISO8601().withMessage('Data de pagamento inválida'),
+    body('notes')
+      .optional()
+      .isLength({ max: 1000 }).withMessage('Observações deve ter no máximo 1000 caracteres')
+  ],
+  remove: [
+    param('id').isUUID().withMessage('ID da venda deve ser um UUID válido'),
+    param('payment_id').isUUID().withMessage('ID do pagamento deve ser um UUID válido')
+  ]
+};
+
+module.exports = paymentValidations;

--- a/backend/src/models/SalePayment.js
+++ b/backend/src/models/SalePayment.js
@@ -1,0 +1,47 @@
+const { DataTypes } = require('sequelize');
+const { sequelize } = require('../config/database');
+
+const SalePayment = sequelize.define('SalePayment', {
+  id: {
+    type: DataTypes.UUID,
+    defaultValue: DataTypes.UUIDV4,
+    primaryKey: true
+  },
+  sale_id: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    references: {
+      model: 'sales',
+      key: 'id'
+    },
+    onUpdate: 'CASCADE',
+    onDelete: 'CASCADE'
+  },
+  amount: {
+    type: DataTypes.DECIMAL(10,2),
+    allowNull: false,
+    validate: {
+      min: 0.01
+    }
+  },
+  payment_method: {
+    type: DataTypes.ENUM('dinheiro','cartao_credito','cartao_debito','pix','transferencia','boleto','cheque','outro'),
+    allowNull: false
+  },
+  payment_date: {
+    type: DataTypes.DATEONLY,
+    allowNull: false,
+    defaultValue: DataTypes.NOW
+  },
+  notes: {
+    type: DataTypes.TEXT,
+    allowNull: true
+  }
+},{
+  tableName: 'sale_payments',
+  indexes:[
+    { fields:['sale_id'] }
+  ]
+});
+
+module.exports = SalePayment;

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -10,6 +10,7 @@ const Trip = require('./Trip');
 const Booking = require('./Booking');
 const Sale = require('./Sale');
 const SaleCustomer = require('./SaleCustomer');
+const SalePayment = require('./SalePayment');
 
 // Definir associações
 // Company associations
@@ -205,6 +206,17 @@ SaleCustomer.belongsTo(Customer, {
   as: 'customer'
 });
 
+// Pagamentos da venda
+Sale.hasMany(SalePayment, {
+  foreignKey: 'sale_id',
+  as: 'payments'
+});
+
+SalePayment.belongsTo(Sale, {
+  foreignKey: 'sale_id',
+  as: 'sale'
+});
+
 Customer.hasMany(SaleCustomer, {
   foreignKey: 'customer_id',
   as: 'sale_customers'
@@ -232,6 +244,7 @@ module.exports = {
   Trip,
   Booking,
   Sale,
-  SaleCustomer
+  SaleCustomer,
+  SalePayment
 };
 

--- a/backend/src/routes/sales.js
+++ b/backend/src/routes/sales.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const SaleController = require('../controllers/SaleController');
+const SalePaymentController = require('../controllers/SalePaymentController');
 const { authenticate } = require('../middleware/auth');
 const { validationResult } = require('express-validator');
 const {
@@ -14,6 +15,7 @@ const {
   listSaleCustomersValidation,
   removeSaleCustomerValidation
 } = require('../middleware/saleValidations');
+const paymentValidations = require('../middleware/paymentValidations');
 
 // Middleware para verificar erros de validação
 const checkValidationErrors = (req, res, next) => {
@@ -65,6 +67,25 @@ router.get('/:id/customers',
 
 // GET /api/sales/:id/voucher - Gerar voucher em PDF
 router.get('/:id/voucher', SaleController.voucher);
+
+// Pagamentos da venda
+router.get('/:id/payments',
+  paymentValidations.list,
+  checkValidationErrors,
+  SalePaymentController.index
+);
+
+router.post('/:id/payments',
+  paymentValidations.create,
+  checkValidationErrors,
+  SalePaymentController.store
+);
+
+router.delete('/:id/payments/:payment_id',
+  paymentValidations.remove,
+  checkValidationErrors,
+  SalePaymentController.destroy
+);
 
 // POST /api/sales/:id/customers - Adicionar cliente à venda
 router.post('/:id/customers',


### PR DESCRIPTION
## Summary
- create `SalePayment` model and associations
- add `SalePaymentController` with list/create/delete operations
- validate payment data in new `paymentValidations` middleware
- expose payment routes under sales

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853406ef150832ca350414c797fd8e5