### PR TITLE
Implement sale payments table

### DIFF
--- a/frontend/src/pages/sales/SaleDetailsDrawer.jsx
+++ b/frontend/src/pages/sales/SaleDetailsDrawer.jsx
@@ -25,12 +25,12 @@ import {
   Car, 
   UserCheck, 
   Clock, 
-  CheckCircle, 
-  X, 
+  CheckCircle,
   AlertCircle,
   
 } from 'lucide-react';
 import './SaleDetailsDrawer.css';
+import SalePaymentsTable from './SalePaymentsTable';
 
 const formatCurrency = (value) =>
   new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(
@@ -73,40 +73,6 @@ const StatusBadge = ({ status }) => {
   );
 };
 
-// Payment Method Badge Component
-const PaymentMethodBadge = ({ method }) => {
-  const methodMap = {
-    dinheiro: 'Dinheiro',
-    cartao_credito: 'Cartão de Crédito',
-    cartao_debito: 'Cartão de Débito',
-    pix: 'PIX',
-    transferencia: 'Transferência',
-    boleto: 'Boleto',
-    parcelado: 'Parcelado',
-    outros: 'Outros'
-  };
-  
-  return <span>{methodMap[method] || method}</span>;
-};
-
-// Payment Status Badge Component
-const PaymentStatusBadge = ({ status }) => {
-  const statusConfig = {
-    pendente: { color: 'bg-yellow-100 text-yellow-800 border-yellow-200', label: 'Pendente' },
-    parcial: { color: 'bg-orange-100 text-orange-800 border-orange-200', label: 'Parcial' },
-    pago: { color: 'bg-green-100 text-green-800 border-green-200', label: 'Pago' },
-    atrasado: { color: 'bg-red-100 text-red-800 border-red-200', label: 'Atrasado' },
-    cancelado: { color: 'bg-gray-100 text-gray-800 border-gray-200', label: 'Cancelado' }
-  };
-  
-  const config = statusConfig[status] || statusConfig.pendente;
-  
-  return (
-    <div className={`inline-flex items-center gap-1.5 px-3 py-1 rounded-full border ${config.color}`}>
-      <span className="text-xs font-medium">{config.label}</span>
-    </div>
-  );
-};
 
 // Priority Badge Component
 const PriorityBadge = ({ priority }) => {
@@ -449,14 +415,7 @@ const SaleDetailsDrawer = ({ open, onOpenChange, sale, customers = [], refreshCu
                     valueClassName="text-lg font-bold text-green-600"
                   />
                   <Divider />
-                  <ValueItem 
-                    label="Método de Pagamento"
-                    value={<PaymentMethodBadge method={sale.payment_method} />}
-                  />
-                  <ValueItem 
-                    label="Status do Pagamento"
-                    value={<PaymentStatusBadge status={sale.payment_status} />}
-                  />
+                  <SalePaymentsTable saleId={sale.id} totalAmount={sale.total_amount} />
                 </div>
               </div>
             </CardContent>
@@ -476,12 +435,6 @@ const SaleDetailsDrawer = ({ open, onOpenChange, sale, customers = [], refreshCu
                   label="Data da Venda"
                   icon={<FileText />}
                   status="completed"
-                />
-                <TimelineItem 
-                  date={sale.payment_date}
-                  label="Pagamento"
-                  icon={<CreditCard />}
-                  status={sale.payment_status === 'pago' ? 'completed' : 'pending'}
                 />
                 <TimelineItem 
                   date={sale.due_date}

--- a/frontend/src/pages/sales/SalePaymentsTable.jsx
+++ b/frontend/src/pages/sales/SalePaymentsTable.jsx
@@ -1,0 +1,220 @@
+import React, { useEffect, useState } from 'react';
+import { salePaymentService } from '../../services/api';
+import { useToast } from '../../contexts/ToastContext';
+import { Plus, Trash2 } from 'lucide-react';
+
+const paymentMethodOptions = [
+  { value: 'dinheiro', label: 'Dinheiro' },
+  { value: 'cartao_credito', label: 'Cartão de Crédito' },
+  { value: 'cartao_debito', label: 'Cartão de Débito' },
+  { value: 'pix', label: 'PIX' },
+  { value: 'transferencia', label: 'Transferência' },
+  { value: 'boleto', label: 'Boleto' },
+  { value: 'parcelado', label: 'Parcelado' },
+  { value: 'outros', label: 'Outros' },
+];
+
+const formatCurrency = (value) =>
+  new Intl.NumberFormat('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+  }).format(value || 0);
+
+const SalePaymentsTable = ({ saleId, totalAmount }) => {
+  const { showSuccess, showError } = useToast();
+  const [payments, setPayments] = useState([]);
+  const [showModal, setShowModal] = useState(false);
+  const [formData, setFormData] = useState({ method: '', amount: '', date: '', notes: '' });
+
+  const fetchPayments = async () => {
+    if (!saleId) return;
+    try {
+      const res = await salePaymentService.list(saleId);
+      setPayments(res.data?.data || res.data || res);
+    } catch (err) {
+      console.error(err);
+      showError('Erro ao buscar pagamentos');
+    }
+  };
+
+  useEffect(() => {
+    fetchPayments();
+  }, [saleId]);
+
+  const totalPaid = payments.reduce((sum, p) => sum + parseFloat(p.amount || 0), 0);
+  const remaining = (parseFloat(totalAmount) || 0) - totalPaid;
+
+  const handleAdd = async (e) => {
+    e.preventDefault();
+    try {
+      await salePaymentService.add(saleId, {
+        method: formData.method,
+        amount: parseFloat(formData.amount),
+        date: formData.date,
+        notes: formData.notes,
+      });
+      showSuccess('Pagamento adicionado');
+      setFormData({ method: '', amount: '', date: '', notes: '' });
+      setShowModal(false);
+      fetchPayments();
+    } catch (err) {
+      console.error(err);
+      showError(err.response?.data?.message || 'Erro ao adicionar pagamento');
+    }
+  };
+
+  const handleDelete = async (id) => {
+    if (!window.confirm('Remover este pagamento?')) return;
+    try {
+      await salePaymentService.remove(saleId, id);
+      showSuccess('Pagamento removido');
+      fetchPayments();
+    } catch (err) {
+      console.error(err);
+      showError(err.response?.data?.message || 'Erro ao remover pagamento');
+    }
+  };
+
+  return (
+    <div className="mt-4">
+      <div className="flex items-center justify-between mb-2">
+        <h4 className="font-medium">Pagamentos</h4>
+        <button
+          type="button"
+          onClick={() => setShowModal(true)}
+          disabled={remaining <= 0}
+          className="flex items-center px-2 py-1 text-sm bg-zapchat-primary text-white rounded-md disabled:opacity-50"
+        >
+          <Plus className="w-4 h-4 mr-1" /> Novo
+        </button>
+      </div>
+      <table className="min-w-full divide-y divide-gray-200 text-sm">
+        <thead className="bg-gray-50">
+          <tr>
+            <th className="px-3 py-2 text-left font-medium text-gray-700">Método</th>
+            <th className="px-3 py-2 text-right font-medium text-gray-700">Valor</th>
+            <th className="px-3 py-2 text-left font-medium text-gray-700">Data</th>
+            <th className="px-3 py-2 text-left font-medium text-gray-700">Notas</th>
+            <th className="px-3 py-2" />
+          </tr>
+        </thead>
+        <tbody className="bg-white divide-y divide-gray-200">
+          {payments.map((p) => (
+            <tr key={p.id}>
+              <td className="px-3 py-2">
+                {paymentMethodOptions.find((o) => o.value === p.method)?.label || p.method}
+              </td>
+              <td className="px-3 py-2 text-right">{formatCurrency(p.amount)}</td>
+              <td className="px-3 py-2">
+                {p.date ? new Date(p.date).toLocaleDateString('pt-BR') : '-'}
+              </td>
+              <td className="px-3 py-2">{p.notes || '-'}</td>
+              <td className="px-3 py-2 text-right">
+                <button
+                  onClick={() => handleDelete(p.id)}
+                  className="text-red-600 hover:text-red-800"
+                >
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              </td>
+            </tr>
+          ))}
+          {payments.length === 0 && (
+            <tr>
+              <td colSpan="5" className="text-center py-4 text-gray-500">
+                Nenhum pagamento registrado
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+      <div className="text-sm text-right mt-2">
+        Total pago: {formatCurrency(totalPaid)} / {formatCurrency(totalAmount)}
+      </div>
+
+      {showModal && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-lg shadow-lg p-6 w-full max-w-sm">
+            <h4 className="text-lg font-medium mb-4">Adicionar Pagamento</h4>
+            <form onSubmit={handleAdd} className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Método
+                </label>
+                <select
+                  required
+                  value={formData.method}
+                  onChange={(e) => setFormData({ ...formData, method: e.target.value })}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-zapchat-primary focus:border-zapchat-primary"
+                >
+                  <option value="">Selecione</option>
+                  {paymentMethodOptions.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Valor
+                </label>
+                <input
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  max={remaining}
+                  required
+                  value={formData.amount}
+                  onChange={(e) => setFormData({ ...formData, amount: e.target.value })}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-zapchat-primary focus:border-zapchat-primary"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Data
+                </label>
+                <input
+                  type="date"
+                  required
+                  value={formData.date}
+                  onChange={(e) => setFormData({ ...formData, date: e.target.value })}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-zapchat-primary focus:border-zapchat-primary"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Notas
+                </label>
+                <textarea
+                  rows="2"
+                  value={formData.notes}
+                  onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-zapchat-primary focus:border-zapchat-primary"
+                />
+              </div>
+              <div className="flex justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={() => setShowModal(false)}
+                  className="px-4 py-2 border border-gray-300 rounded-md text-sm hover:bg-gray-50"
+                >
+                  Cancelar
+                </button>
+                <button
+                  type="submit"
+                  disabled={parseFloat(formData.amount || 0) > remaining}
+                  className="px-4 py-2 bg-zapchat-primary text-white rounded-md text-sm hover:bg-zapchat-medium disabled:opacity-50"
+                >
+                  Salvar
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SalePaymentsTable;

--- a/frontend/src/pages/sales/Sales.jsx
+++ b/frontend/src/pages/sales/Sales.jsx
@@ -95,9 +95,6 @@ const Sales = () => {
     tax_amount: 0,
     status: 'orcamento',
     priority: 'media',
-    payment_method: '',
-    payment_status: 'pendente',
-    payment_date: new Date().toISOString().split('T')[0],
     due_date: new Date().toISOString().split('T')[0],
     installments: 1,
     sale_date: new Date().toISOString().split('T')[0],
@@ -129,17 +126,6 @@ const Sales = () => {
     { value: 'media', label: 'Média', color: 'bg-yellow-100 text-yellow-800' },
     { value: 'alta', label: 'Alta', color: 'bg-orange-100 text-orange-800' },
     { value: 'urgente', label: 'Urgente', color: 'bg-red-100 text-red-800' }
-  ];
-
-  const paymentMethodOptions = [
-    { value: 'dinheiro', label: 'Dinheiro' },
-    { value: 'cartao_credito', label: 'Cartão de Crédito' },
-    { value: 'cartao_debito', label: 'Cartão de Débito' },
-    { value: 'pix', label: 'PIX' },
-    { value: 'transferencia', label: 'Transferência' },
-    { value: 'boleto', label: 'Boleto' },
-    { value: 'parcelado', label: 'Parcelado' },
-    { value: 'outros', label: 'Outros' }
   ];
 
   useEffect(() => {
@@ -369,9 +355,6 @@ const Sales = () => {
         tax_amount: sale.tax_amount || 0,
         status: sale.status || 'orcamento',
         priority: sale.priority || 'media',
-        payment_method: sale.payment_method || '',
-        payment_status: sale.payment_status || 'pendente',
-        payment_date: sale.payment_date ? sale.payment_date.split('T')[0] : '',
         due_date: sale.due_date ? sale.due_date.split('T')[0] : '',
         installments: sale.installments || 1,
         sale_date: sale.sale_date ? sale.sale_date.split('T')[0] : '',
@@ -458,9 +441,6 @@ const Sales = () => {
       tax_amount: 0,
       status: 'orcamento',
       priority: 'media',
-      payment_method: '',
-      payment_status: 'pendente',
-      payment_date: new Date().toISOString().split('T')[0],
       due_date: new Date().toISOString().split('T')[0],
       installments: 1,
       sale_date: new Date().toISOString().split('T')[0],
@@ -1235,53 +1215,6 @@ const Sales = () => {
                       </div>
 
                       <div className="grid grid-cols-2 gap-4">
-                        <div>
-                          <label className="block text-sm font-medium text-gray-700 mb-1">
-                            Método de Pagamento
-                          </label>
-                          <select
-                            value={formData.payment_method}
-                            onChange={(e) => setFormData({ ...formData, payment_method: e.target.value })}
-                            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-zapchat-primary focus:border-zapchat-primary"
-                          >
-                            <option value="">Selecione</option>
-                            {paymentMethodOptions.map((option) => (
-                              <option key={option.value} value={option.value}>
-                                {option.label}
-                              </option>
-                            ))}
-                          </select>
-                        </div>
-                        <div>
-                          <label className="block text-sm font-medium text-gray-700 mb-1">
-                            Status do Pagamento
-                          </label>
-                          <select
-                            value={formData.payment_status}
-                            onChange={(e) => setFormData({ ...formData, payment_status: e.target.value })}
-                            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-zapchat-primary focus:border-zapchat-primary"
-                          >
-                            {paymentStatusOptions.map((option) => (
-                              <option key={option.value} value={option.value}>
-                                {option.label}
-                              </option>
-                            ))}
-                          </select>
-                        </div>
-                      </div>
-
-                      <div className="grid grid-cols-2 gap-4">
-                        <div>
-                          <label className="block text-sm font-medium text-gray-700 mb-1">
-                            Data de Pagamento
-                          </label>
-                          <input
-                            type="date"
-                            value={formData.payment_date}
-                            onChange={(e) => setFormData({ ...formData, payment_date: e.target.value })}
-                            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-zapchat-primary focus:border-zapchat-primary"
-                          />
-                        </div>
                         <div>
                           <label className="block text-sm font-medium text-gray-700 mb-1">
                             Data de Vencimento

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -283,6 +283,12 @@ export const saleService = {
   downloadVoucher: (id) => api.get(`/sales/${id}/voucher`, { responseType: 'blob' }),
 };
 
+export const salePaymentService = {
+  list: (saleId) => api.get(`/sales/${saleId}/payments`),
+  add: (saleId, data) => api.post(`/sales/${saleId}/payments`, data),
+  remove: (saleId, paymentId) => api.delete(`/sales/${saleId}/payments/${paymentId}`),
+};
+
 // Serviços de reservas
 export const bookingService = {
   getAll: (params) => api.get('/bookings', { params }),


### PR DESCRIPTION
## Summary
- drop payment fields from sale form
- add salePaymentsTable to show/edit payments
- refresh SaleDetailsDrawer with new table
- expose salePaymentService API helpers

## Testing
- `pnpm lint` *(fails: no-unused-vars and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68534070e42c832cb618d6e5856e884a