### PR TITLE
Add Settings screen

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -23,6 +23,7 @@ import UsersPage from './pages/users/Users';
 import Companies from './pages/companies/Companies';
 import Profile from './pages/profile/Profile';
 import ChangePassword from './pages/profile/ChangePassword';
+import Settings from './pages/settings/Settings';
 
 // Placeholder component for bookings
 
@@ -80,6 +81,7 @@ const AppContent = () => {
             <Route path="sales" element={<Sales />} />
             <Route path="bookings" element={<Bookings />} />
             <Route path="profile" element={<Profile />} />
+            <Route path="settings" element={<Settings />} />
             <Route path="change-password" element={<ChangePassword />} />
           </Route>
           

--- a/frontend/src/pages/settings/Settings.jsx
+++ b/frontend/src/pages/settings/Settings.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const Settings = () => {
+  return (
+    <div className="bg-white rounded-lg shadow-card p-6">
+      <h2 className="text-2xl font-bold mb-4">Configurações</h2>
+      <p className="text-gray-600">Tela de configurações em desenvolvimento.</p>
+    </div>
+  );
+};
+
+export default Settings;


### PR DESCRIPTION
## Summary
- add placeholder settings page
- wire up Settings page route within protected routes

## Testing
- `pnpm build` in `frontend`
- `npm test` in `backend`
- `pnpm lint` *(fails: cannot pass existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685439b9083c832cb3080bf7cfee36d6