### PR TITLE
Implement settings CRUD endpoints and tests

### DIFF
--- a/backend/src/controllers/GeneralSettingController.js
+++ b/backend/src/controllers/GeneralSettingController.js
@@ -1,4 +1,5 @@
 const { GeneralSetting } = require('../models');
+const { validationResult } = require('express-validator');
 
 class GeneralSettingController {
   static async get(req, res, next) {
@@ -13,6 +14,15 @@ class GeneralSettingController {
 
   static async update(req, res, next) {
     try {
+      const errors = validationResult(req);
+      if (!errors.isEmpty()) {
+        return res.status(400).json({
+          success: false,
+          error: 'Dados inválidos',
+          details: errors.array()
+        });
+      }
+
       const companyId = req.user.company_id;
       const { logo, guidelines } = req.body;
       let setting = await GeneralSetting.findOne({ where: { company_id: companyId } });
@@ -22,6 +32,53 @@ class GeneralSettingController {
         setting = await GeneralSetting.create({ company_id: companyId, logo, guidelines });
       }
       res.status(200).json({ success: true, data: { setting } });
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  static async create(req, res, next) {
+    try {
+      const errors = validationResult(req);
+      if (!errors.isEmpty()) {
+        return res.status(400).json({
+          success: false,
+          error: 'Dados inválidos',
+          details: errors.array()
+        });
+      }
+
+      const companyId = req.user.company_id;
+      const { logo, guidelines } = req.body;
+
+      const existing = await GeneralSetting.findOne({ where: { company_id: companyId } });
+      if (existing) {
+        return res.status(409).json({
+          success: false,
+          error: 'Configurações já cadastradas'
+        });
+      }
+
+      const setting = await GeneralSetting.create({ company_id: companyId, logo, guidelines });
+      res.status(201).json({ success: true, data: { setting } });
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  static async delete(req, res, next) {
+    try {
+      const companyId = req.user.company_id;
+      const setting = await GeneralSetting.findOne({ where: { company_id: companyId } });
+      if (!setting) {
+        return res.status(404).json({
+          success: false,
+          error: 'Configurações não encontradas'
+        });
+      }
+
+      await setting.destroy();
+      res.status(200).json({ success: true, message: 'Configurações removidas' });
     } catch (err) {
       next(err);
     }

--- a/backend/src/middleware/generalSettingValidations.js
+++ b/backend/src/middleware/generalSettingValidations.js
@@ -1,0 +1,26 @@
+const { body } = require('express-validator');
+
+const generalSettingValidations = {
+  create: [
+    body('logo')
+      .optional({ nullable: true })
+      .isBase64()
+      .withMessage('Logo deve estar em Base64'),
+    body('guidelines')
+      .optional({ nullable: true })
+      .isString()
+      .withMessage('Guidelines deve ser um texto')
+  ],
+  update: [
+    body('logo')
+      .optional({ nullable: true })
+      .isBase64()
+      .withMessage('Logo deve estar em Base64'),
+    body('guidelines')
+      .optional({ nullable: true })
+      .isString()
+      .withMessage('Guidelines deve ser um texto')
+  ]
+};
+
+module.exports = generalSettingValidations;

--- a/backend/src/routes/settings.js
+++ b/backend/src/routes/settings.js
@@ -2,10 +2,13 @@ const express = require('express');
 const router = express.Router();
 const GeneralSettingController = require('../controllers/GeneralSettingController');
 const { authenticate } = require('../middleware/auth');
+const generalSettingValidations = require('../middleware/generalSettingValidations');
 
 router.use(authenticate);
 
 router.get('/', GeneralSettingController.get);
-router.put('/', GeneralSettingController.update);
+router.post('/', generalSettingValidations.create, GeneralSettingController.create);
+router.put('/', generalSettingValidations.update, GeneralSettingController.update);
+router.delete('/', GeneralSettingController.delete);
 
 module.exports = router;

--- a/backend/src/settings.test.js
+++ b/backend/src/settings.test.js
@@ -1,0 +1,77 @@
+const request = require('supertest');
+const { app } = require('./server');
+const { initializeDatabase, closeConnection } = require('./config/database');
+const { Company, User, GeneralSetting } = require('./models');
+
+describe('Settings Endpoints', () => {
+  let token;
+
+  beforeAll(async () => {
+    process.env.DB_RECREATE_FORCE = 'true';
+    process.env.BCRYPT_ROUNDS = '4';
+    await initializeDatabase();
+
+    const company = await Company.create({
+      name: 'Test Company',
+      cnpj: '12345678000100',
+      email: 'company@test.com'
+    });
+
+    await User.create({
+      firstName: 'Test',
+      lastName: 'User',
+      email: 'user@test.com',
+      password: 'testpass',
+      role: 'admin',
+      isActive: true,
+      emailVerified: true,
+      company_id: company.id
+    });
+
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'user@test.com', password: 'testpass' });
+    token = res.body.data.tokens.accessToken;
+  });
+
+  afterAll(async () => {
+    await closeConnection();
+  });
+
+  it('POST /api/settings should create settings', async () => {
+    const res = await request(app)
+      .post('/api/settings')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ logo: Buffer.from('logo').toString('base64'), guidelines: 'Use mask' });
+    expect(res.statusCode).toBe(201);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('GET /api/settings should retrieve settings', async () => {
+    const res = await request(app)
+      .get('/api/settings')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data.setting.guidelines).toBe('Use mask');
+  });
+
+  it('PUT /api/settings should update settings', async () => {
+    const res = await request(app)
+      .put('/api/settings')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ guidelines: 'Updated guidelines' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data.setting.guidelines).toBe('Updated guidelines');
+  });
+
+  it('DELETE /api/settings should remove settings', async () => {
+    const res = await request(app)
+      .delete('/api/settings')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.success).toBe(true);
+
+    const setting = await GeneralSetting.findOne();
+    expect(setting).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add validation for GeneralSettings
- support POST/DELETE for settings
- implement create and delete methods
- test settings endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685439bd35ec832c918e9276d477a134