### PR TITLE
Add default GeneralSetting on seed

### DIFF
--- a/backend/src/database/seeders.js
+++ b/backend/src/database/seeders.js
@@ -1,4 +1,4 @@
-const { Company, User } = require('../models');
+const { Company, User, GeneralSetting } = require('../models');
 const bcrypt = require('bcryptjs');
 
 /**
@@ -38,6 +38,15 @@ async function seedDatabase() {
     });
 
     console.log('✅ Empresa exemplo criada:', exampleCompany.name);
+
+    // Criar configurações gerais padrão da empresa
+    await GeneralSetting.create({
+      company_id: exampleCompany.id,
+      logo: Buffer.from('placeholder'),
+      guidelines: ''
+    });
+
+    console.log('✅ Configurações gerais criadas para empresa:', exampleCompany.name);
 
     // Criar usuário master
     const masterUser = await User.create({


### PR DESCRIPTION
## Summary
- insert GeneralSetting creation during seeding so dev databases include a placeholder logo and blank guidelines

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_685439c0a7a8832c8648ca73cfe061ce