### PR TITLE
Add High Contrast mode toggle

### DIFF
--- a/frontend/src/components/layout/ModernLayout.jsx
+++ b/frontend/src/components/layout/ModernLayout.jsx
@@ -21,7 +21,8 @@ import {
   LogOut,
   ChevronDown,
   Sun,
-  Moon
+  Moon,
+  Contrast
 } from 'lucide-react';
 
 const ModernLayout = () => {
@@ -31,6 +32,10 @@ const ModernLayout = () => {
   });
   const [userMenuOpen, setUserMenuOpen] = useState(false);
   const [darkMode, setDarkMode] = useState(false);
+  const [highContrast, setHighContrast] = useState(() => {
+    const saved = localStorage.getItem('highContrast');
+    return saved ? saved === 'true' : false;
+  });
   const { user, logout } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
@@ -41,6 +46,11 @@ const ModernLayout = () => {
     if (saved === 'true') {
       setDarkMode(true);
       document.documentElement.classList.add('dark');
+    }
+    const hc = localStorage.getItem('highContrast');
+    if (hc === 'true') {
+      setHighContrast(true);
+      document.documentElement.classList.add('high-contrast');
     }
   }, []);
 
@@ -53,6 +63,16 @@ const ModernLayout = () => {
     }
     localStorage.setItem('darkMode', darkMode);
   }, [darkMode]);
+
+  // Aplicar classe high-contrast ao alterar
+  useEffect(() => {
+    if (highContrast) {
+      document.documentElement.classList.add('high-contrast');
+    } else {
+      document.documentElement.classList.remove('high-contrast');
+    }
+    localStorage.setItem('highContrast', highContrast);
+  }, [highContrast]);
 
   // Persistir estado do sidebar
   useEffect(() => {
@@ -172,7 +192,7 @@ const ModernLayout = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className={`min-h-screen bg-gray-50 ${highContrast ? 'contrast-bg' : ''}`}>
       {/* Sidebar */}
       <div className={`fixed inset-y-0 left-0 z-50 w-64 bg-white shadow-xl transform ${
         sidebarOpen ? 'translate-x-0' : '-translate-x-full'
@@ -316,11 +336,19 @@ const ModernLayout = () => {
               </div>
 
               {/* Theme Toggle */}
-              <button 
+              <button
                 onClick={() => setDarkMode(!darkMode)}
                 className="p-2 text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors"
               >
                 {darkMode ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
+              </button>
+
+              {/* High Contrast Toggle */}
+              <button
+                onClick={() => setHighContrast(!highContrast)}
+                className="p-2 text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors"
+              >
+                <Contrast className={`w-5 h-5 ${highContrast ? 'text-zapchat-medium' : ''}`} />
               </button>
 
               {/* Notifications */}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -279,3 +279,17 @@ input:focus, textarea:focus, select:focus {
 .react-select__option--is-selected {
   @apply bg-zapchat-primary text-white;
 }
+
+/* High Contrast Mode */
+.high-contrast body {
+  @apply bg-white text-black dark:bg-black dark:text-white;
+}
+
+.high-contrast .contrast-border {
+  @apply border-black dark:border-white;
+}
+
+.high-contrast .contrast-bg {
+  @apply bg-white text-black dark:bg-black dark:text-white;
+}
+


### PR DESCRIPTION
## Summary
- add high contrast mode CSS helpers
- persist and toggle high contrast in `ModernLayout`
- expose a button to turn high contrast on/off next to the dark mode toggle

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm test` *(fails: Jest encountered an unexpected token)*
- `pnpm lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685441518f8c832cbcc7d12e3c5b70cc