### PR TITLE
Add notifications page and unread badge

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -24,6 +24,7 @@ import Companies from './pages/companies/Companies';
 import Profile from './pages/profile/Profile';
 import ChangePassword from './pages/profile/ChangePassword';
 import Settings from './pages/settings/Settings';
+import Notifications from './pages/notifications/Notifications';
 
 // Placeholder component for bookings
 
@@ -79,6 +80,7 @@ const AppContent = () => {
             <Route path="customers" element={<Customers />} />
             <Route path="trips" element={<Trips />} />
             <Route path="sales" element={<Sales />} />
+            <Route path="notifications" element={<Notifications />} />
             <Route path="bookings" element={<Bookings />} />
             <Route path="settings" element={<Settings />} />
             <Route path="profile" element={<Profile />} />

--- a/frontend/src/components/layout/ModernLayout.jsx
+++ b/frontend/src/components/layout/ModernLayout.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Outlet, useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
+import { notificationService } from '../../services/api';
 import {
   Home,
   Building2,
@@ -31,6 +32,7 @@ const ModernLayout = () => {
   });
   const [userMenuOpen, setUserMenuOpen] = useState(false);
   const [darkMode, setDarkMode] = useState(false);
+  const [unreadCount, setUnreadCount] = useState(0);
   const { user, logout } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
@@ -58,6 +60,23 @@ const ModernLayout = () => {
   useEffect(() => {
     localStorage.setItem('sidebarOpen', sidebarOpen);
   }, [sidebarOpen]);
+
+  // Carregar contagem de notificações não lidas
+  useEffect(() => {
+    const loadCount = async () => {
+      try {
+        const res = await notificationService.unreadCount();
+        const count = res.data?.count ?? res.count ?? 0;
+        setUnreadCount(count);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    loadCount();
+    const handler = () => loadCount();
+    window.addEventListener('notifications:update', handler);
+    return () => window.removeEventListener('notifications:update', handler);
+  }, []);
 
   const menuItems = [
     { 
@@ -324,11 +343,16 @@ const ModernLayout = () => {
               </button>
 
               {/* Notifications */}
-              <button className="relative p-2 text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors">
+              <button
+                onClick={() => navigate('/notifications')}
+                className="relative p-2 text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors"
+              >
                 <Bell className="w-5 h-5" />
-                <span className="absolute -top-1 -right-1 w-5 h-5 bg-red-500 text-white text-xs rounded-full flex items-center justify-center">
-                  2
-                </span>
+                {unreadCount > 0 && (
+                  <span className="absolute -top-1 -right-1 w-5 h-5 bg-red-500 text-white text-xs rounded-full flex items-center justify-center">
+                    {unreadCount}
+                  </span>
+                )}
               </button>
 
               {/* User Menu */}

--- a/frontend/src/pages/notifications/Notifications.jsx
+++ b/frontend/src/pages/notifications/Notifications.jsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useState } from 'react';
+import { notificationService } from '../../services/api';
+import { useToast } from '../../contexts/ToastContext';
+import { CheckCircle } from 'lucide-react';
+
+const Notifications = () => {
+  const { showError, showSuccess } = useToast();
+  const [notifications, setNotifications] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    loadNotifications();
+  }, []);
+
+  const loadNotifications = async () => {
+    try {
+      setLoading(true);
+      const res = await notificationService.list();
+      const data = res.data?.notifications || res.data?.data || res.notifications || [];
+      setNotifications(data);
+    } catch (err) {
+      console.error(err);
+      showError('Erro ao carregar notificações');
+    } finally {
+      setLoading(false);
+      window.dispatchEvent(new CustomEvent('notifications:update'));
+    }
+  };
+
+  const handleMarkAsRead = async (id) => {
+    try {
+      await notificationService.markAsRead(id);
+      showSuccess('Notificação marcada como lida');
+      setNotifications((prev) => prev.map((n) => n.id === id ? { ...n, read: true } : n));
+      window.dispatchEvent(new CustomEvent('notifications:update'));
+    } catch (err) {
+      console.error(err);
+      showError('Erro ao marcar como lida');
+    }
+  };
+
+  const formatRelativeTime = (dateString) => {
+    if (!dateString) return '';
+    const diff = Date.now() - new Date(dateString).getTime();
+    const minutes = Math.floor(diff / 60000);
+    if (minutes < 60) return `${minutes} minutos atrás`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours} horas atrás`;
+    const days = Math.floor(hours / 24);
+    return `${days} dias atrás`;
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Notificações</h1>
+          <p className="text-gray-600">Acompanhe suas notificações recentes</p>
+        </div>
+      </div>
+
+      {loading ? (
+        <p>Carregando...</p>
+      ) : (
+        <div className="bg-white rounded-lg shadow-card p-6 space-y-4">
+          {notifications.length === 0 ? (
+            <p className="text-gray-500 text-sm">Nenhuma notificação.</p>
+          ) : (
+            notifications.map((n) => (
+              <div key={n.id} className="flex justify-between items-start border-b last:border-b-0 pb-4 last:pb-0">
+                <div className="flex-1">
+                  <p className={`text-sm ${n.read ? 'text-gray-500' : 'text-gray-900 font-medium'}`}>{n.message || n.title}</p>
+                  <p className="text-xs text-gray-400">{formatRelativeTime(n.createdAt)}</p>
+                </div>
+                {!n.read && (
+                  <button
+                    onClick={() => handleMarkAsRead(n.id)}
+                    className="text-zapchat-medium hover:text-zapchat-dark text-sm flex items-center space-x-1"
+                  >
+                    <CheckCircle className="w-4 h-4" />
+                    <span>Marcar como lida</span>
+                  </button>
+                )}
+              </div>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Notifications;

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -328,4 +328,11 @@ export const settingService = {
   update: (data) => api.put('/settings', data),
 };
 
+// Serviços de notificações
+export const notificationService = {
+  list: (params) => api.get('/notifications', { params }),
+  markAsRead: (id) => api.patch(`/notifications/${id}/read`),
+  unreadCount: () => api.get('/notifications/unread-count'),
+};
+
 export default api;


### PR DESCRIPTION
## Summary
- create Notifications page with list and mark-as-read action
- route `/notifications`
- API notificationService for listing and marking read
- show unread notifications in ModernLayout bell icon

## Testing
- `npm test` *(fails: jest not found)*
- `pnpm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_685441511b70832ca8ef0cf5c04a01c9