### PR TITLE
Add unread notifications count endpoint

### DIFF
--- a/backend/src/controllers/AuthController.js
+++ b/backend/src/controllers/AuthController.js
@@ -195,7 +195,7 @@ class AuthController {
 
       // Buscar usuário
       const user = await User.findByPk(decoded.userId, {
-        include: ['Company']
+        include: ['company']
       });
 
       if (!user || !user.isActive) {
@@ -207,7 +207,7 @@ class AuthController {
       }
 
       // Verificar se empresa está ativa (para usuários não-master)
-      if (user.company_id && (!user.Company || !user.Company.isActive)) {
+      if (user.company_id && (!user.company || !user.company.isActive)) {
         return res.status(401).json({
           success: false,
           error: 'Empresa inativa',

--- a/backend/src/controllers/NotificationController.js
+++ b/backend/src/controllers/NotificationController.js
@@ -109,6 +109,17 @@ class NotificationController {
       next(error);
     }
   }
+
+  static async getUnreadCount(req, res, next) {
+    try {
+      const count = await Notification.count({
+        where: { user_id: req.user.id, read: false }
+      });
+      res.status(200).json({ success: true, data: { count } });
+    } catch (error) {
+      next(error);
+    }
+  }
 }
 
 module.exports = NotificationController;

--- a/backend/src/routes/notifications.js
+++ b/backend/src/routes/notifications.js
@@ -7,6 +7,7 @@ const notificationValidations = require('../middleware/notificationValidations')
 router.use(authenticate);
 
 router.get('/', NotificationController.listByUser);
+router.get('/unread-count', NotificationController.getUnreadCount);
 router.post('/', notificationValidations.create, NotificationController.create);
 router.get('/:id', notificationValidations.validateId, NotificationController.getById);
 router.put('/:id', notificationValidations.validateId, NotificationController.update);


### PR DESCRIPTION
## Summary
- add `GET /notifications/unread-count` route and controller method
- fix company alias usage in auth refresh flow

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685448605e08832cb45f29bcad3ed8b5