### PR TITLE
Fix DrawerOverlay forwardRef

### DIFF
--- a/frontend/src/components/ui/drawer.jsx
+++ b/frontend/src/components/ui/drawer.jsx
@@ -27,20 +27,20 @@ function DrawerClose({
   return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />;
 }
 
-function DrawerOverlay({
-  className,
-  ...props
-}) {
+const DrawerOverlay = React.forwardRef(({ className, ...props }, ref) => {
   return (
     <DrawerPrimitive.Overlay
       data-slot="drawer-overlay"
+      ref={ref}
       className={cn(
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
         className
       )}
       {...props} />
   );
-}
+});
+
+DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName;
 
 function DrawerContent({
   className,


### PR DESCRIPTION
## Summary
- convert DrawerOverlay to use `React.forwardRef`
- forward the ref to `DrawerPrimitive.Overlay`
- expose overlay's display name for debugging

## Testing
- `pnpm lint` *(fails: 45 problems)*
- `pnpm test --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68545ea21bd0832c98a7d41cf20ba095