### PR TITLE
Add color field to trips

### DIFF
--- a/backend/src/database/migrations/202405081_add_color_to_trips.sql
+++ b/backend/src/database/migrations/202405081_add_color_to_trips.sql
@@ -1,0 +1,5 @@
+-- Adicionar coluna color à tabela trips
+ALTER TABLE trips ADD COLUMN color VARCHAR(7) DEFAULT '#99CD85';
+
+-- Garantir valor padrão em registros existentes
+UPDATE trips SET color = '#99CD85' WHERE color IS NULL;

--- a/backend/src/middleware/tripValidations.js
+++ b/backend/src/middleware/tripValidations.js
@@ -21,7 +21,10 @@ const tripValidations = {
     body('status')
       .optional()
       .isIn(['ativo', 'inativo','cancelado'])
-      .withMessage('Status inválido')
+      .withMessage('Status inválido'),
+    body('color')
+      .optional()
+      .isHexColor().withMessage('Cor deve ser um hexadecimal válido')
   ],
   update: [
     body('title')
@@ -43,7 +46,10 @@ const tripValidations = {
     body('status')
       .optional()
       .isIn(['planejado', 'confirmado', 'em_andamento', 'concluido', 'cancelado'])
-      .withMessage('Status inválido')
+      .withMessage('Status inválido'),
+    body('color')
+      .optional()
+      .isHexColor().withMessage('Cor deve ser um hexadecimal válido')
   ],
   updateStatus: [
     body('status')

--- a/backend/src/models/Trip.js
+++ b/backend/src/models/Trip.js
@@ -52,6 +52,14 @@ const Trip = sequelize.define('Trip', {
       }
     }
   },
+  color: {
+    type: DataTypes.STRING(7),
+    allowNull: false,
+    defaultValue: '#99CD85',
+    validate: {
+      is: /^#([0-9A-Fa-f]{6})$/,
+    },
+  },
   company_id: {
     type: DataTypes.UUID,
     allowNull: false,

--- a/frontend/src/pages/trips/Trips.jsx
+++ b/frontend/src/pages/trips/Trips.jsx
@@ -35,6 +35,7 @@ const Trips = () => {
     priceTrips: '',
     type: 'turismo',
     status: 'ativo',
+    color: '#99CD85',
     company_id: '',
   });
 
@@ -80,6 +81,7 @@ const Trips = () => {
       priceTrips: '',
       type: 'turismo',
       status: 'ativo',
+      color: '#99CD85',
       company_id: '',
     });
   };
@@ -123,6 +125,7 @@ const Trips = () => {
       priceTrips: trip.priceTrips || '',
       type: trip.type || 'turismo',
       status: trip.status || 'ativo',
+      color: trip.color || '#99CD85',
       company_id: trip.company_id || '',
     });
     setShowModal(true);
@@ -242,7 +245,7 @@ const Trips = () => {
           </thead>
           <tbody>
             {trips.map((trip) => (
-              <tr key={trip.id} className="border-t">
+              <tr key={trip.id} className="border-t" style={{ borderLeft: `4px solid ${trip.color || '#99CD85'}` }}>
                 <td className="px-3 py-2">{trip.title}</td>
                 <td className="px-3 py-2 capitalize">{trip.type}</td>
                 <td className="px-3 py-2">
@@ -336,6 +339,14 @@ const Trips = () => {
                     <option key={status.value} value={status.value}>{status.label}</option>
                   ))}
                 </select>
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1">Cor</label>
+                <input
+                  type="color"
+                  value={formData.color}
+                  onChange={(e) => setFormData({ ...formData, color: e.target.value })}
+                  className="w-16 h-10 border rounded-md p-0" />
               </div>
               {isMaster() && (
                 <div>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -266,8 +266,15 @@ export const customerService = {
 export const tripService = {
   getAll: (params) => api.get('/trips', { params }),
   getById: (id) => api.get(`/trips/${id}`),
-  create: (data) => api.post('/trips', data),
-  update: (id, data) => api.put(`/trips/${id}`, data),
+  create: (data) => {
+    const payload = { color: '#99CD85', ...data };
+    return api.post('/trips', payload);
+  },
+  update: (id, data) => {
+    const payload = { ...data };
+    if (!payload.color) payload.color = '#99CD85';
+    return api.put(`/trips/${id}`, payload);
+  },
   delete: (id) => api.delete(`/trips/${id}`),
   updateStatus: (id, data) => api.patch(`/trips/${id}/status`, data),
 };


### PR DESCRIPTION
## Summary
- add `color` column to Trip model
- add SQL migration for `trips.color`
- validate hex color in Trip validations
- send color in trip API service
- update Trips page with color picker and row styling

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68557d0d734c832ca02f1b153f69b209