### PR TITLE
Update delivery_date handling

### DIFF
--- a/backend/src/controllers/SaleController.js
+++ b/backend/src/controllers/SaleController.js
@@ -117,13 +117,21 @@ class SaleController {
         distinct: true
       });
 
+      const salesData = sales.map((s) => {
+        const obj = s.toJSON();
+        if (obj.delivery_date) {
+          obj.delivery_date = new Date(obj.delivery_date).toISOString();
+        }
+        return obj;
+      });
+
       // Calcular estatísticas
       const stats = await SaleController.getSalesStats(user);
 
       res.json({
         success: true,
         data: {
-          sales,
+          sales: salesData,
           pagination: {
             current_page: parseInt(page),
             per_page: parseInt(limit),
@@ -200,9 +208,14 @@ class SaleController {
         });
       }
 
+      const saleData = sale.toJSON();
+      if (saleData.delivery_date) {
+        saleData.delivery_date = new Date(saleData.delivery_date).toISOString();
+      }
+
       res.json({
         success: true,
-        data: sale
+        data: saleData
       });
     } catch (error) {
       console.error('Erro ao buscar venda:', error);
@@ -338,10 +351,15 @@ class SaleController {
         ]
       });
 
+      const createdData = createdSale.toJSON();
+      if (createdData.delivery_date) {
+        createdData.delivery_date = new Date(createdData.delivery_date).toISOString();
+      }
+
       res.status(201).json({
         success: true,
         message: 'Venda criada com sucesso',
-        data: createdSale
+        data: createdData
       });
     } catch (error) {
       console.error('Erro ao criar venda:', error);
@@ -476,10 +494,15 @@ class SaleController {
         ]
       });
 
+      const updatedData = updatedSale.toJSON();
+      if (updatedData.delivery_date) {
+        updatedData.delivery_date = new Date(updatedData.delivery_date).toISOString();
+      }
+
       res.json({
         success: true,
         message: 'Venda atualizada com sucesso',
-        data: updatedSale
+        data: updatedData
       });
     } catch (error) {
       console.error('Erro ao atualizar venda:', error);

--- a/backend/src/database/migrations/202407151_alter_sales_delivery_date.sql
+++ b/backend/src/database/migrations/202407151_alter_sales_delivery_date.sql
@@ -1,0 +1,9 @@
+-- Alterar coluna delivery_date para DATETIME
+-- Cria nova coluna temporária
+ALTER TABLE sales ADD COLUMN delivery_date_new DATETIME;
+-- Copia os valores existentes
+UPDATE sales SET delivery_date_new = delivery_date;
+-- Remove a coluna antiga
+ALTER TABLE sales DROP COLUMN delivery_date;
+-- Renomeia a nova coluna
+ALTER TABLE sales RENAME COLUMN delivery_date_new TO delivery_date;

--- a/backend/src/middleware/saleValidations.js
+++ b/backend/src/middleware/saleValidations.js
@@ -112,7 +112,9 @@ const createSaleValidation = [
   body('delivery_date')
     .optional()
     .isISO8601()
-    .withMessage('Data de entrega deve ser uma data válida'),
+    .withMessage('Data de entrega deve ser uma data e hora válidas')
+    .matches(/T\d{2}:\d{2}/)
+    .withMessage('Data de entrega deve incluir hora'),
 
   body('commission_percentage')
     .optional()
@@ -279,7 +281,9 @@ const updateSaleValidation = [
   body('delivery_date')
     .optional()
     .isISO8601()
-    .withMessage('Data de entrega deve ser uma data válida'),
+    .withMessage('Data de entrega deve ser uma data e hora válidas')
+    .matches(/T\d{2}:\d{2}/)
+    .withMessage('Data de entrega deve incluir hora'),
 
   body('commission_percentage')
     .optional()

--- a/backend/src/models/Sale.js
+++ b/backend/src/models/Sale.js
@@ -167,9 +167,9 @@ const Sale = sequelize.define('Sale', {
   },
   
   delivery_date: {
-    type: DataTypes.DATEONLY,
+    type: DataTypes.DATE,
     allowNull: true,
-    comment: 'Data de entrega/realização do serviço'
+    comment: 'Data e hora de entrega/realização do serviço'
   },
   
   // Parcelamento

--- a/frontend/src/pages/sales/SaleDetailsDrawer.jsx
+++ b/frontend/src/pages/sales/SaleDetailsDrawer.jsx
@@ -39,8 +39,14 @@ const formatCurrency = (value) =>
 
 const formatDate = (dateString) => {
     if (!dateString) return '-';
-    const date = new Date(dateString + 'T00:00:00');
-    return date.toLocaleDateString('pt-BR');
+    const date = new Date(dateString);
+    return date.toLocaleString('pt-BR', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    });
   };
 
 const calculateDaysLeft = (dateString) => {
@@ -364,8 +370,8 @@ const SaleDetailsDrawer = ({ open, onOpenChange, sale, customers = [], refreshCu
               <InfoItem
                 icon={<User className="w-4 h-4 text-blue-500" />}
                 label="Data de Execução"
-                value={formatDate(sale.sale_date)}
-              />              
+                value={formatDate(sale.delivery_date)}
+              />
               {sale.seller && (
                 <InfoItem 
                   icon={<UserCheck className="w-4 h-4 text-indigo-500" />}

--- a/frontend/src/pages/sales/Sales.jsx
+++ b/frontend/src/pages/sales/Sales.jsx
@@ -96,7 +96,7 @@ const Sales = () => {
     priority: 'media',
     installments: 1,
     sale_date: new Date().toISOString().split('T')[0],
-    delivery_date: new Date().toISOString().split('T')[0],
+    delivery_date: new Date().toISOString().slice(0,16),
     commission_percentage: 0,
     notes: '',
     internal_notes: ''
@@ -347,7 +347,7 @@ const Sales = () => {
         priority: sale.priority || 'media',
         installments: sale.installments || 1,
         sale_date: sale.sale_date ? sale.sale_date.split('T')[0] : '',
-        delivery_date: sale.delivery_date ? sale.delivery_date.split('T')[0] : '',
+        delivery_date: sale.delivery_date ? new Date(sale.delivery_date).toISOString().slice(0,16) : '',
         commission_percentage: sale.commission_percentage || 0,
         notes: sale.notes || '',
         internal_notes: sale.internal_notes || ''
@@ -432,7 +432,7 @@ const Sales = () => {
       priority: 'media',
       installments: 1,
       sale_date: new Date().toISOString().split('T')[0],
-      delivery_date: new Date().toISOString().split('T')[0],
+      delivery_date: new Date().toISOString().slice(0,16),
       commission_percentage: 0,
       notes: '',
       internal_notes: ''
@@ -457,10 +457,16 @@ const Sales = () => {
     }).format(value || 0);
   };
 
-  const formatDate = (dateString) => {
-    if (!dateString) return '-';
-    const date = new Date(dateString + 'T00:00:00');
-    return date.toLocaleDateString('pt-BR');
+  const formatDateTime = (value) => {
+    if (!value) return '-';
+    const date = new Date(value);
+    return date.toLocaleString('pt-BR', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    });
   };
 
   const getStatusBadge = (status, options) => {
@@ -717,7 +723,7 @@ const Sales = () => {
                       {getStatusBadge(sale.status, statusOptions)}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
-                      {formatDate(sale.sale_date)}
+                      {formatDateTime(sale.delivery_date || sale.sale_date)}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                       <div className="flex justify-end space-x-2">
@@ -1123,7 +1129,7 @@ const Sales = () => {
                             Data de Entrega
                           </label>
                           <input
-                            type="date"
+                            type="datetime-local"
                             value={formData.delivery_date}
                             onChange={(e) => setFormData({ ...formData, delivery_date: e.target.value })}
                             className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-zapchat-primary focus:border-zapchat-primary"


### PR DESCRIPTION
## Summary
- allow timestamps for `Sale.delivery_date`
- validate `delivery_date` as ISO datetime
- expose delivery datetime in controller responses
- use datetime-local inputs in sales forms
- show full datetime in sales lists and details
- add SQL migration to convert column

## Testing
- `npm test` in `backend`
- `npm test -- --passWithNoTests` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68557d0ee3fc832c85ed5f25d3cfc71d