### PR TITLE
Fix trip status filter and unify status values

### DIFF
--- a/frontend/src/pages/customers/Customers.jsx
+++ b/frontend/src/pages/customers/Customers.jsx
@@ -24,7 +24,7 @@ const Customers = () => {
     emergencyContact: '',
     emergencyPhone: '',
     observations: '',
-    status: 'Ativo'
+    status: 'ativo'
   });
 
   const statusOptions = [
@@ -139,7 +139,7 @@ const Customers = () => {
       emergencyContact: customer.emergencyContact || '',
       emergencyPhone: customer.emergencyPhone || '',
       observations: customer.observations || '',
-      status: customer.status || 'ACTIVE'
+      status: customer.status || 'ativo'
     });
     setShowModal(true);
   };
@@ -173,7 +173,7 @@ const Customers = () => {
       emergencyContact: '',
       emergencyPhone: '',
       observations: '',
-      status: 'ACTIVE'
+      status: 'ativo'
     });
   };
 
@@ -260,7 +260,7 @@ const Customers = () => {
             <div className="ml-3">
               <p className="text-sm font-medium text-gray-600">Ativos</p>
               <p className="text-lg font-semibold text-gray-900">
-                {customers.filter(c => c.status === 'ACTIVE').length}
+                {customers.filter(c => c.status === 'ativo').length}
               </p>
             </div>
           </div>

--- a/frontend/src/pages/drivers/Drivers.jsx
+++ b/frontend/src/pages/drivers/Drivers.jsx
@@ -27,7 +27,7 @@ const Drivers = () => {
     city: '',
     state: '',
     zipCode: '',
-    status: 'ACTIVE',
+    status: 'ativo',
     vehicleId: ''
   });
 
@@ -40,10 +40,10 @@ const Drivers = () => {
   ];
 
   const statusOptions = [
-    { value: 'ACTIVE', label: 'Ativo', color: 'bg-green-100 text-green-800' },
-    { value: 'INACTIVE', label: 'Inativo', color: 'bg-red-100 text-red-800' },
-    { value: 'VACATION', label: 'Férias', color: 'bg-blue-100 text-blue-800' },
-    { value: 'SICK_LEAVE', label: 'Licença Médica', color: 'bg-yellow-100 text-yellow-800' }
+    { value: 'ativo', label: 'Ativo', color: 'bg-green-100 text-green-800' },
+    { value: 'inativo', label: 'Inativo', color: 'bg-red-100 text-red-800' },
+    { value: 'ferias', label: 'Férias', color: 'bg-blue-100 text-blue-800' },
+    { value: 'licenca', label: 'Licença Médica', color: 'bg-yellow-100 text-yellow-800' }
   ];
 
   useEffect(() => {
@@ -89,13 +89,6 @@ const Drivers = () => {
       const [firstName, ...lastParts] = formData.name.trim().split(' ');
       const lastName = lastParts.join(' ') || 'Sobrenome';
 
-      const statusMap = {
-        ACTIVE: 'ativo',
-        INACTIVE: 'inativo',
-        VACATION: 'ferias',
-        SICK_LEAVE: 'licenca'
-      };
-
       const submitData = {
         firstName: firstName || 'Nome',
         lastName,
@@ -111,7 +104,7 @@ const Drivers = () => {
         licenseNumber: formData.cnh,
         licenseCategory: formData.cnhCategory,
         licenseExpiry: formData.cnhExpiry || null,
-        status: statusMap[formData.status] || 'ativo',
+        status: formData.status || 'ativo',
         vehicleId: formData.vehicleId || null
       };
 
@@ -160,7 +153,7 @@ const Drivers = () => {
       city: driver.city || '',
       state: driver.state || '',
       zipCode: driver.zipCode || '',
-      status: driver.status || 'ACTIVE',
+      status: driver.status || 'ativo',
       vehicleId: driver.vehicleId || ''
     });
     setShowModal(true);
@@ -195,7 +188,7 @@ const Drivers = () => {
       city: '',
       state: '',
       zipCode: '',
-      status: 'ACTIVE',
+      status: 'ativo',
       vehicleId: ''
     });
   };
@@ -286,7 +279,7 @@ const Drivers = () => {
             <div className="ml-3">
               <p className="text-sm font-medium text-gray-600">Ativos</p>
               <p className="text-lg font-semibold text-gray-900">
-                {drivers.filter(d => d.status === 'ACTIVE').length}
+                {drivers.filter(d => d.status === 'ativo').length}
               </p>
             </div>
           </div>
@@ -654,7 +647,7 @@ const Drivers = () => {
                         className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-zapchat-primary focus:border-zapchat-primary"
                       >
                         <option value="">Nenhum veículo</option>
-                        {vehicles.filter(v => v.status === 'ACTIVE').map(vehicle => (
+                        {vehicles.filter(v => v.status === 'ativo').map(vehicle => (
                           <option key={vehicle.id} value={vehicle.id}>
                             {vehicle.plate} - {vehicle.brand} {vehicle.model}
                           </option>

--- a/frontend/src/pages/trips/Trips.jsx
+++ b/frontend/src/pages/trips/Trips.jsx
@@ -219,7 +219,7 @@ const Trips = () => {
             <div className="ml-3">
               <p className="text-sm font-medium text-gray-600">Ativos</p>
               <p className="text-lg font-semibold text-gray-900">
-                {trips.filter(c => c.status === 'ACTIVE').length}
+                {trips.filter(c => c.status === 'ativo').length}
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- use lowercase status strings across trip, customer and driver pages
- count active trips, customers and drivers using `ativo`
- adjust driver status options and defaults to Portuguese values

## Testing
- `pnpm install`
- `npx jest --passWithNoTests`
- `pnpm lint` *(fails: no-unused-vars and react-hooks errors)*

------
https://chatgpt.com/codex/tasks/task_e_68557d0f7994832c9536eec3eb2b736c