### PR TITLE
Fix dashboard calendar color

### DIFF
--- a/backend/src/controllers/SaleController.js
+++ b/backend/src/controllers/SaleController.js
@@ -69,7 +69,7 @@ class SaleController {
           {
             model: Trip,
             as: 'trip',
-            attributes: ['id', 'title', 'type', 'maxPassengers']
+            attributes: ['id', 'title', 'type', 'maxPassengers', 'color']
           },
           {
             model: Driver,

--- a/frontend/src/pages/dashboard/ModernDashboard.jsx
+++ b/frontend/src/pages/dashboard/ModernDashboard.jsx
@@ -86,6 +86,7 @@ const ModernDashboard = () => {
           id: s.id,
           title: s.trip ? s.trip.title : s.sale_number,
           start: s.sale_date,
+          color: s.trip?.color,
         }));
         setSalesEvents(events);
       } catch (err) {


### PR DESCRIPTION
## Summary
- expose trip color in sales list API
- render sales calendar events using trip color

## Testing
- `npm test` (fails: jest not found)
- `npm test` in frontend (fails: jest not found)


------
https://chatgpt.com/codex/tasks/task_e_68558d5ad530832cab3a86cd8b635acc