### PR TITLE
Add accessories management page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -20,6 +20,7 @@ import Customers from './pages/customers/Customers';
 import Trips from './pages/trips/Trips';
 import Sales from './pages/sales/Sales';
 import UsersPage from './pages/users/Users';
+import Accessories from './pages/accessories/Accessories';
 import Companies from './pages/companies/Companies';
 import Profile from './pages/profile/Profile';
 import ChangePassword from './pages/profile/ChangePassword';
@@ -80,6 +81,7 @@ const AppContent = () => {
             <Route path="customers" element={<Customers />} />
             <Route path="trips" element={<Trips />} />
             <Route path="sales" element={<Sales />} />
+            <Route path="acessorios" element={<Accessories />} />
             <Route path="notifications" element={<Notifications />} />
             <Route path="bookings" element={<Bookings />} />
             <Route path="settings" element={<Settings />} />

--- a/frontend/src/components/layout/Layout.jsx
+++ b/frontend/src/components/layout/Layout.jsx
@@ -9,6 +9,7 @@ import {
   UserCircle,
   MapPin,
   Calendar,
+  Package,
   BarChart3,
   Menu,
   X,
@@ -70,6 +71,12 @@ const Layout = () => {
       name: 'Clientes',
       href: '/customers',
       icon: UserCircle,
+      show: true,
+    },
+    {
+      name: 'Acessórios',
+      href: '/acessorios',
+      icon: Package,
       show: true,
     },
     {

--- a/frontend/src/components/layout/ModernLayout.jsx
+++ b/frontend/src/components/layout/ModernLayout.jsx
@@ -12,6 +12,7 @@ import {
   MapPin,
   Calendar,
   CalendarCheck,
+  Package,
   DollarSign,
   Bell,
   Search,
@@ -148,18 +149,26 @@ const ModernLayout = () => {
       color: 'from-teal-500 to-teal-600',
       badge: '5'
     },
-    { 
-      id: 'customers', 
-      label: 'Clientes', 
-      icon: UserCircle, 
+    {
+      id: 'customers',
+      label: 'Clientes',
+      icon: UserCircle,
       path: '/customers',
       color: 'from-pink-500 to-pink-600',
       badge: '6'
     },
-    { 
-      id: 'trips', 
-      label: 'Passeios', 
-      icon: MapPin, 
+    {
+      id: 'accessories',
+      label: 'Acessórios',
+      icon: Package,
+      path: '/acessorios',
+      color: 'from-yellow-500 to-yellow-600',
+      badge: '8'
+    },
+    {
+      id: 'trips',
+      label: 'Passeios',
+      icon: MapPin,
       path: '/trips',
       color: 'from-emerald-500 to-emerald-600',
       badge: '7'

--- a/frontend/src/pages/accessories/Accessories.jsx
+++ b/frontend/src/pages/accessories/Accessories.jsx
@@ -1,0 +1,190 @@
+import React, { useState, useEffect } from 'react';
+import { accessoryService } from '../../services/api';
+import { useToast } from '../../contexts/ToastContext';
+import { Plus, Edit, Trash2, Save, X } from 'lucide-react';
+
+const emptyForm = { name: '', value: '', description: '' };
+
+const Accessories = () => {
+  const { showSuccess, showError } = useToast();
+  const [accessories, setAccessories] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [showModal, setShowModal] = useState(false);
+  const [editing, setEditing] = useState(null);
+  const [formData, setFormData] = useState(emptyForm);
+
+  const loadAccessories = async () => {
+    try {
+      setLoading(true);
+      const res = await accessoryService.getAll();
+      const list = res.data?.accessories || res.accessories || res.data || [];
+      setAccessories(list);
+    } catch (err) {
+      console.error(err);
+      showError('Erro ao carregar acessórios');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadAccessories();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const resetForm = () => setFormData(emptyForm);
+
+  const openCreate = () => {
+    resetForm();
+    setEditing(null);
+    setShowModal(true);
+  };
+
+  const openEdit = (acc) => {
+    setFormData({
+      name: acc.name || '',
+      value: acc.value,
+      description: acc.description || '',
+    });
+    setEditing(acc);
+    setShowModal(true);
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const payload = {
+      name: formData.name,
+      value: parseFloat(formData.value) || 0,
+      description: formData.description,
+    };
+    try {
+      if (editing) {
+        await accessoryService.update(editing.id, payload);
+        showSuccess('Acessório atualizado com sucesso');
+      } else {
+        await accessoryService.create(payload);
+        showSuccess('Acessório criado com sucesso');
+      }
+      setShowModal(false);
+      setEditing(null);
+      resetForm();
+      loadAccessories();
+    } catch (err) {
+      console.error(err);
+      showError('Erro ao salvar acessório');
+    }
+  };
+
+  const handleDelete = async (id) => {
+    if (!window.confirm('Deseja excluir este acessório?')) return;
+    try {
+      await accessoryService.delete(id);
+      showSuccess('Acessório excluído com sucesso');
+      loadAccessories();
+    } catch (err) {
+      console.error(err);
+      showError('Erro ao excluir acessório');
+    }
+  };
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl font-bold text-gray-900">Acessórios</h1>
+        <button
+          onClick={openCreate}
+          className="bg-zapchat-primary text-white px-4 py-2 rounded-md hover:bg-zapchat-medium flex items-center"
+        >
+          <Plus className="w-4 h-4 mr-2" /> Novo Acessório
+        </button>
+      </div>
+
+      {loading ? (
+        <div className="flex justify-center items-center py-12">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-zapchat-primary"></div>
+        </div>
+      ) : (
+        <div className="bg-white rounded-lg shadow p-6 overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead>
+              <tr>
+                <th className="px-3 py-2 text-left text-sm font-medium text-gray-500">Nome</th>
+                <th className="px-3 py-2 text-left text-sm font-medium text-gray-500">Valor</th>
+                <th className="px-3 py-2 text-left text-sm font-medium text-gray-500">Descrição</th>
+                <th className="px-3 py-2" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {accessories.map((a) => (
+                <tr key={a.id}>
+                  <td className="px-3 py-2 whitespace-nowrap">{a.name}</td>
+                  <td className="px-3 py-2 whitespace-nowrap">
+                    {Number(a.value).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}
+                  </td>
+                  <td className="px-3 py-2">{a.description}</td>
+                  <td className="px-3 py-2 whitespace-nowrap text-right text-sm">
+                    <button onClick={() => openEdit(a)} className="text-blue-600 hover:underline mr-3">
+                      <Edit className="w-4 h-4 inline" />
+                    </button>
+                    <button onClick={() => handleDelete(a.id)} className="text-red-600 hover:underline">
+                      <Trash2 className="w-4 h-4 inline" />
+                    </button>
+                  </td>
+                </tr>
+              ))}
+              {accessories.length === 0 && (
+                <tr>
+                  <td colSpan="4" className="text-center py-8 text-sm text-gray-500">
+                    Nenhum acessório encontrado
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {showModal && (
+        <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+          <div className="bg-white rounded-lg shadow-lg w-full max-w-md p-6 space-y-4">
+            <h2 className="text-xl font-semibold mb-4">{editing ? 'Editar Acessório' : 'Novo Acessório'}</h2>
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <input
+                type="text"
+                placeholder="Nome"
+                value={formData.name}
+                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                className="border border-gray-300 rounded-md px-3 py-2 w-full"
+                required
+              />
+              <input
+                type="number"
+                step="0.01"
+                placeholder="Valor"
+                value={formData.value}
+                onChange={(e) => setFormData({ ...formData, value: e.target.value })}
+                className="border border-gray-300 rounded-md px-3 py-2 w-full"
+                required
+              />
+              <textarea
+                placeholder="Descrição"
+                value={formData.description}
+                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                className="border border-gray-300 rounded-md px-3 py-2 w-full"
+              />
+              <div className="flex justify-end space-x-2">
+                <button type="button" onClick={() => setShowModal(false)} className="px-4 py-2 bg-gray-200 rounded-md flex items-center">
+                  <X className="w-4 h-4 mr-1" /> Cancelar
+                </button>
+                <button type="submit" className="px-4 py-2 bg-zapchat-primary text-white rounded-md flex items-center">
+                  <Save className="w-4 h-4 mr-1" /> Salvar
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Accessories;

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -313,6 +313,15 @@ export const bookingService = {
   getRevenue: (params) => api.get('/bookings/revenue', { params }),
 };
 
+// Serviços de acessórios
+export const accessoryService = {
+  getAll: (params) => api.get('/accessories', { params }),
+  getById: (id) => api.get(`/accessories/${id}`),
+  create: (data) => api.post('/accessories', data),
+  update: (id, data) => api.put(`/accessories/${id}`, data),
+  delete: (id) => api.delete(`/accessories/${id}`),
+};
+
 // Serviços de configurações gerais
 export const settingsService = {
   get: () => api.get('/settings'),


### PR DESCRIPTION
## Summary
- implement Accessories CRUD page in frontend
- expose accessories API service
- register /acessorios route and menu entry

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in backend *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68558f08e3d4832caf277fb23ceace5f