### PR TITLE
Fix SaleDetailsDrawer status null and add ErrorBoundary

### DIFF
--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error('ErrorBoundary caught an error', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="p-4">
+          <h1 className="text-xl font-bold mb-2">Algo deu errado.</h1>
+          <pre className="text-red-500 whitespace-pre-wrap">{this.state.error?.message}</pre>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
+import ErrorBoundary from './components/ErrorBoundary.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </StrictMode>,
 )

--- a/frontend/src/pages/sales/SaleDetailsDrawer.jsx
+++ b/frontend/src/pages/sales/SaleDetailsDrawer.jsx
@@ -311,7 +311,7 @@ const SaleDetailsDrawer = ({ open, onOpenChange, sale, customers = [], refreshCu
               </DrawerTitle>
             </div>
             <div className="flex items-center gap-2">
-              <StatusBadge status={saleData.status} />
+              <StatusBadge status={saleData?.status} />
             </div>
           </div>
         </DrawerHeader>


### PR DESCRIPTION
## Summary
- avoid reading status on null sale data in `SaleDetailsDrawer`
- add a simple `ErrorBoundary` component
- wrap app with `ErrorBoundary`

## Testing
- `pnpm exec jest --passWithNoTests`
- `pnpm lint` *(fails: no-unused-vars and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68581d42b784832c8adf5b6db3e71825