### PR TITLE
Add null guard to SaleDetailsDrawer

### DIFF
--- a/frontend/src/pages/sales/SaleDetailsDrawer.jsx
+++ b/frontend/src/pages/sales/SaleDetailsDrawer.jsx
@@ -297,7 +297,7 @@ const SaleDetailsDrawer = ({ open, onOpenChange, sale, customers = [], refreshCu
     }
   };
 
-  if (!sale) return null;
+  if (!sale || !saleData) return null;
   
   return (
     <Drawer open={open} onOpenChange={onOpenChange} direction="right">


### PR DESCRIPTION
## Summary
- avoid rendering SaleDetailsDrawer when sale data is missing

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d8f3fb9e0832e9d5707ad9a107202