### PR TITLE
Fix Sale hooks for accessories

### DIFF
--- a/backend/src/__tests__/saleAccessoryHooks.test.js
+++ b/backend/src/__tests__/saleAccessoryHooks.test.js
@@ -1,0 +1,96 @@
+const { sequelize, Sale, SaleAccessory, Accessory, Company, Customer, Trip, User } = require('../models');
+
+beforeAll(async () => {
+  process.env.NODE_ENV = 'test';
+  await sequelize.sync({ force: true });
+});
+
+afterAll(async () => {
+  await sequelize.close();
+});
+
+describe('Sale hooks with accessories', () => {
+  let company, user, customer, trip, accessory;
+
+  beforeEach(async () => {
+    await sequelize.sync({ force: true });
+    company = await Company.create({
+      name: 'Test Co',
+      cnpj: '12345678000190',
+      email: 'co@test.com'
+    });
+    user = await User.create({
+      firstName: 'Seller',
+      lastName: 'User',
+      email: 'seller@test.com',
+      password: 'secret',
+      company_id: company.id
+    });
+    customer = await Customer.create({
+      firstName: 'John',
+      lastName: 'Doe',
+      email: 'john@test.com',
+      phone: '11999999999',
+      company_id: company.id
+    });
+    trip = await Trip.create({
+      title: 'Trip',
+      maxPassengers: 10,
+      priceTrips: 0,
+      type: 'turismo',
+      color: '#FFFFFF',
+      company_id: company.id
+    });
+    accessory = await Accessory.create({
+      name: 'Hat',
+      value: 10,
+      company_id: company.id
+    });
+  });
+
+  test('adding accessory recalculates total_amount', async () => {
+    const sale = await Sale.create({
+      subtotal: 100,
+      discount_amount: 0,
+      tax_amount: 0,
+      trip_id: trip.id,
+      customer_id: customer.id,
+      company_id: company.id,
+      seller_id: user.id,
+      created_by: user.id
+    });
+
+    await SaleAccessory.create({ sale_id: sale.id, accessory_id: accessory.id, quantity: 2 });
+    await sale.reload({ include: [{ model: SaleAccessory, as: 'sale_accessories', include: [{ model: Accessory, as: 'accessory' }] }] });
+    sale.changed('total_amount', true);
+    await sale.save();
+    const updated = await Sale.findByPk(sale.id);
+    expect(parseFloat(updated.total_amount)).toBeCloseTo(120);
+  });
+
+  test('removing accessory recalculates total_amount', async () => {
+    const sale = await Sale.create({
+      subtotal: 100,
+      discount_amount: 0,
+      tax_amount: 0,
+      trip_id: trip.id,
+      customer_id: customer.id,
+      company_id: company.id,
+      seller_id: user.id,
+      created_by: user.id
+    });
+
+    const sa = await SaleAccessory.create({ sale_id: sale.id, accessory_id: accessory.id, quantity: 1 });
+    await sale.reload({ include: [{ model: SaleAccessory, as: 'sale_accessories', include: [{ model: Accessory, as: 'accessory' }] }] });
+    sale.changed('total_amount', true);
+    await sale.save();
+    expect(parseFloat(sale.total_amount)).toBeCloseTo(110);
+
+    await sa.destroy();
+    await sale.reload({ include: [{ model: SaleAccessory, as: 'sale_accessories', include: [{ model: Accessory, as: 'accessory' }] }] });
+    sale.changed('total_amount', true);
+    await sale.save();
+    const updated = await Sale.findByPk(sale.id);
+    expect(parseFloat(updated.total_amount)).toBeCloseTo(100);
+  });
+});

--- a/backend/src/models/Sale.js
+++ b/backend/src/models/Sale.js
@@ -340,10 +340,18 @@ const Sale = sequelize.define('Sale', {
       const taxAmount = parseFloat(sale.tax_amount) || 0;
 
       let accessoriesTotal = 0;
-      if (Array.isArray(sale.accessories)) {
+      // Preferir a associação "accessories". Caso esteja ausente,
+      // verificar "sale_accessories" carregada por outros controladores.
+      if (Array.isArray(sale.accessories) && sale.accessories.length) {
         sale.accessories.forEach(acc => {
           const quantity = parseInt(acc.quantity || 1);
           const value = parseFloat(acc.value || (acc.Accessory && acc.Accessory.value) || 0);
+          accessoriesTotal += value * quantity;
+        });
+      } else if (Array.isArray(sale.sale_accessories)) {
+        sale.sale_accessories.forEach(sa => {
+          const quantity = parseInt(sa.quantity || 1);
+          const value = parseFloat(sa.accessory?.value || 0);
           accessoriesTotal += value * quantity;
         });
       }
@@ -370,10 +378,18 @@ const Sale = sequelize.define('Sale', {
       const taxAmount = parseFloat(sale.tax_amount) || 0;
 
       let accessoriesTotal = 0;
-      if (Array.isArray(sale.accessories)) {
+      // Preferir a associação "accessories". Caso esteja ausente,
+      // verificar "sale_accessories" carregada por outros controladores.
+      if (Array.isArray(sale.accessories) && sale.accessories.length) {
         sale.accessories.forEach(acc => {
           const quantity = parseInt(acc.quantity || 1);
           const value = parseFloat(acc.value || (acc.Accessory && acc.Accessory.value) || 0);
+          accessoriesTotal += value * quantity;
+        });
+      } else if (Array.isArray(sale.sale_accessories)) {
+        sale.sale_accessories.forEach(sa => {
+          const quantity = parseInt(sa.quantity || 1);
+          const value = parseFloat(sa.accessory?.value || 0);
           accessoriesTotal += value * quantity;
         });
       }


### PR DESCRIPTION
## Summary
- allow Sale hooks to read `sale_accessories` when `accessories` association isn't loaded
- document reload logic in `SaleAccessoryController`
- add Jest tests covering accessory add/remove totals

## Testing
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d924b370c832ea2d3188331137dae