### PR TITLE
Refresh sales list after closing details

### DIFF
--- a/frontend/src/pages/sales/Sales.jsx
+++ b/frontend/src/pages/sales/Sales.jsx
@@ -47,6 +47,13 @@ const Sales = () => {
   const [modalMode, setModalMode] = useState('create');
   const [showDetailsModal, setShowDetailsModal] = useState(false);
   const [selectedSale, setSelectedSale] = useState(null);
+  const handleDetailsDrawerChange = (open) => {
+    setShowDetailsModal(open);
+    if (!open) {
+      fetchSales();
+      fetchStats();
+    }
+  };
   const [searchTerm, setSearchTerm] = useState('');
   const [statusFilter, setStatusFilter] = useState('');
   const [startDateFilter, setStartDateFilter] = useState('');
@@ -985,7 +992,7 @@ const Sales = () => {
       {/* Modal de Detalhes da Venda */}
       <SaleDetailsDrawer
         open={showDetailsModal && !!selectedSale}
-        onOpenChange={setShowDetailsModal}
+        onOpenChange={handleDetailsDrawerChange}
         sale={selectedSale}
         customers={saleCustomers}
         refreshCustomers={() => selectedSale && fetchSaleCustomers(selectedSale.id)}


### PR DESCRIPTION
## Summary
- refresh sales and stats when closing sale details drawer

## Testing
- `pnpm install` *(fails: Request was cancelled – proxy blocked)*
- `pnpm test` *(fails: Request was cancelled – proxy blocked)*
- `pnpm lint` *(fails: Request was cancelled – proxy blocked)*
- `pnpm test` in backend *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d96ec2ebc832ea8b6c88471705c16