### PR TITLE
Handle settings logo upload via FormData

### DIFF
--- a/backend/src/middleware/generalSettingValidations.js
+++ b/backend/src/middleware/generalSettingValidations.js
@@ -12,10 +12,6 @@ const generalSettingValidations = {
       .withMessage('Guidelines deve ser um texto')
   ],
   update: [
-    body('logo')
-      .optional({ nullable: true })
-      .isBase64()
-      .withMessage('Logo deve estar em Base64'),
     body('guidelines')
       .optional({ nullable: true })
       .isString()

--- a/frontend/src/pages/settings/Settings.jsx
+++ b/frontend/src/pages/settings/Settings.jsx
@@ -19,6 +19,7 @@ const Settings = () => {
   const { showSuccess, showError } = useToast();
   const [guidelines, setGuidelines] = useState('');
   const [logoPreview, setLogoPreview] = useState('');
+  const [logoFile, setLogoFile] = useState(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -52,6 +53,7 @@ const Settings = () => {
       showError('Envie apenas arquivos de imagem');
       return;
     }
+    setLogoFile(file);
     const reader = new FileReader();
     reader.onloadend = () => setLogoPreview(reader.result);
     reader.readAsDataURL(file);
@@ -60,7 +62,12 @@ const Settings = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      await settingsService.update({ logo: logoPreview || null, guidelines });
+      const formData = new FormData();
+      if (logoFile) {
+        formData.append('logo', logoFile);
+      }
+      formData.append('guidelines', guidelines);
+      await settingsService.update(formData);
       showSuccess('Configurações salvas');
     } catch (err) {
       console.error(err);

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -331,9 +331,12 @@ export const accessoryService = {
 // Serviços de configurações gerais
 export const settingsService = {
   get: () => api.get('/settings'),
-  update: (data) => api.put('/settings', data),
-  create: (data) => api.post('/settings', data), 
-  remove: (id) => api.delete(`/settings/${id}`), 
+  update: (data) =>
+    api.put('/settings', data, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    }),
+  create: (data) => api.post('/settings', data),
+  remove: (id) => api.delete(`/settings/${id}`),
 };
 
 // Serviços de atividades


### PR DESCRIPTION
## Summary
- allow updating settings logo with multipart form data
- adjust validations for updating settings
- handle logo file in settings page and service

## Testing
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d9c06ef38832e9b9f503569665b93