### PR TITLE
Fix dashboard sales query date range

### DIFF
--- a/frontend/src/pages/dashboard/ModernDashboard.jsx
+++ b/frontend/src/pages/dashboard/ModernDashboard.jsx
@@ -74,8 +74,10 @@ const ModernDashboard = () => {
     const loadSales = async () => {
       try {
         const start = new Date();
+        start.setDate(1);
         const end = new Date();
         end.setMonth(end.getMonth() + 1);
+        end.setDate(0);
         const params = {
           start_date: start.toISOString().slice(0, 10),
           end_date: end.toISOString().slice(0, 10),


### PR DESCRIPTION
## Summary
- fetch sales for the whole month instead of starting from today so past sales appear in the calendar

## Testing
- `npm test` (fails: `jest: not found`)
- `npm run lint` in `frontend` (fails: missing `@eslint/js`)
- `npm run lint` in `backend` (no script)


------
https://chatgpt.com/codex/tasks/task_e_685da0e12644832e8a65b31c1c6cbfe4