### PR TITLE
Fix customer search case sensitivity

### DIFF
--- a/backend/src/controllers/CustomerController.js
+++ b/backend/src/controllers/CustomerController.js
@@ -27,11 +27,11 @@ class CustomerController {
 
       if (search) {
         where[Op.or] = [
-          { firstName: { [Op.like]: `%${search}%` } },
-          { lastName: { [Op.like]: `%${search}%` } },
-          { email: { [Op.like]: `%${search}%` } },
-          { cpf: { [Op.like]: `%${search}%` } },
-          { phone: { [Op.like]: `%${search}%` } }
+          { firstName: { [Op.iLike]: `%${search}%` } },
+          { lastName: { [Op.iLike]: `%${search}%` } },
+          { email: { [Op.iLike]: `%${search}%` } },
+          { cpf: { [Op.iLike]: `%${search}%` } },
+          { phone: { [Op.iLike]: `%${search}%` } }
         ];
       }
 

--- a/backend/src/controllers/SaleController.js
+++ b/backend/src/controllers/SaleController.js
@@ -48,12 +48,12 @@ class SaleController {
       // Busca textual
       if (search) {
         where[Op.or] = [
-          { sale_number: { [Op.like]: `%${search}%` } },
-          { description: { [Op.like]: `%${search}%` } },
-          { notes: { [Op.like]: `%${search}%` } },
-          { '$customer.first_name$': { [Op.like]: `%${search}%` } },
-          { '$customer.last_name$': { [Op.like]: `%${search}%` } },
-          { '$customer.email$': { [Op.like]: `%${search}%` } }
+          { sale_number: { [Op.iLike]: `%${search}%` } },
+          { description: { [Op.iLike]: `%${search}%` } },
+          { notes: { [Op.iLike]: `%${search}%` } },
+          { '$customer.first_name$': { [Op.iLike]: `%${search}%` } },
+          { '$customer.last_name$': { [Op.iLike]: `%${search}%` } },
+          { '$customer.email$': { [Op.iLike]: `%${search}%` } }
         ];
       }
 


### PR DESCRIPTION
## Summary
- make customer search in customer listing use `Op.iLike`
- make sale search also use `Op.iLike` so customer fields are case-insensitive

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dbbb1da20832e9fc733779cd5c883