### PR TITLE
Fix overflow on dashboard calendar events

### DIFF
--- a/frontend/src/pages/dashboard/ModernDashboard.jsx
+++ b/frontend/src/pages/dashboard/ModernDashboard.jsx
@@ -195,8 +195,9 @@ const ModernDashboard = () => {
       <Tooltip>
         <TooltipTrigger asChild>
           <div
-            className="px-1 rounded-sm"
+            className="px-1 rounded-sm truncate"
             style={{ backgroundColor: bg, color: text }}
+          >
             {eventInfo.timeText && <b>{eventInfo.timeText} </b>}
             {eventInfo.event.title}
           </div>


### PR DESCRIPTION
## Summary
- prevent long calendar entries from overflowing by truncating text

## Testing
- `pnpm test` *(fails: FetchError - registry.npmjs.org blocked)*
- `npm test` in backend *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb6794778832eaec6b7477c00713b