### PR TITLE
Fix auto contrast application

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -285,6 +285,10 @@ input:focus, textarea:focus, select:focus {
   @apply bg-white text-black dark:bg-black dark:text-white;
 }
 
+.high-contrast {
+  filter: grayscale(1) contrast(1.2);
+}
+
 .high-contrast .contrast-border {
   @apply border-black dark:border-white;
 }

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -4,6 +4,18 @@ import './index.css'
 import App from './App.jsx'
 import ErrorBoundary from './components/ErrorBoundary.jsx'
 
+// Aplicar classes iniciais de tema antes de renderizar a aplicação
+const initTheme = () => {
+  if (localStorage.getItem('darkMode') === 'true') {
+    document.documentElement.classList.add('dark')
+  }
+  if (localStorage.getItem('highContrast') === 'true') {
+    document.documentElement.classList.add('high-contrast')
+  }
+}
+
+initTheme()
+
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <ErrorBoundary>

--- a/frontend/src/pages/auth/Login.jsx
+++ b/frontend/src/pages/auth/Login.jsx
@@ -10,6 +10,7 @@ const Login = () => {
   });
   const [showPassword, setShowPassword] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const highContrast = localStorage.getItem('highContrast') === 'true';
 
   const { login, error, clearError } = useAuth();
   const navigate = useNavigate();
@@ -40,7 +41,9 @@ const Login = () => {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-[#CFE0BC] to-[#99CD85] py-12 px-4 sm:px-6 lg:px-8">
+    <div
+      className={`min-h-screen flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8 ${highContrast ? 'contrast-bg' : 'bg-gradient-to-br from-[#CFE0BC] to-[#99CD85]'}`}
+    >
       <div className="max-w-md w-full space-y-8">
         <div className="bg-white rounded-lg shadow-xl p-8">
           <div className="text-center">

--- a/frontend/src/pages/auth/Register.jsx
+++ b/frontend/src/pages/auth/Register.jsx
@@ -15,6 +15,7 @@ const Register = () => {
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const highContrast = localStorage.getItem('highContrast') === 'true';
   const [validationErrors, setValidationErrors] = useState({});
 
   const { register, error, clearError } = useAuth();
@@ -88,7 +89,9 @@ const Register = () => {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-[#CFE0BC] to-[#99CD85] py-12 px-4 sm:px-6 lg:px-8">
+    <div
+      className={`min-h-screen flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8 ${highContrast ? 'contrast-bg' : 'bg-gradient-to-br from-[#CFE0BC] to-[#99CD85]'}`}
+    >
       <div className="max-w-md w-full space-y-8">
         <div className="bg-white rounded-lg shadow-xl p-8">
           <div className="text-center">


### PR DESCRIPTION
## Summary
- initialize theme classes from localStorage before React renders
- add global filter for high-contrast mode
- respect high-contrast mode on login and register pages

## Testing
- `pnpm test` *(fails: fetch to registry blocked)*
- `npm test` in backend *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ee4b3850c832e898ac8cd4e7bb6bd