### PR TITLE
Add reporting controller and routes

### DIFF
--- a/backend/src/controllers/ReportController.js
+++ b/backend/src/controllers/ReportController.js
@@ -1,0 +1,109 @@
+const { Sale, SalePayment, Trip, User, sequelize } = require('../models');
+const { Op } = require('sequelize');
+
+class ReportController {
+  static buildCompanyFilter(user) {
+    if (user.isMaster() && user.company_id) {
+      return { company_id: user.company_id };
+    }
+    if (!user.isMaster()) {
+      return { company_id: user.company_id };
+    }
+    return {};
+  }
+
+  static async salesReport(req, res, next) {
+    try {
+      const { start_date, end_date } = req.query;
+      const where = ReportController.buildCompanyFilter(req.user);
+      if (start_date && end_date) {
+        where.sale_date = { [Op.between]: [new Date(start_date), new Date(end_date)] };
+      }
+      const sales = await Sale.findAll({
+        where,
+        include: [
+          { model: Trip, as: 'trip', attributes: ['id', 'title'] },
+          { model: User, as: 'seller', attributes: ['id', 'firstName', 'lastName'] }
+        ],
+        order: [['sale_date', 'ASC']]
+      });
+      res.json({ success: true, data: { sales } });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async dailyTrips(req, res, next) {
+    try {
+      const { start_date, end_date } = req.query;
+      const where = ReportController.buildCompanyFilter(req.user);
+      if (start_date && end_date) {
+        where.sale_date = { [Op.between]: [new Date(start_date), new Date(end_date)] };
+      }
+      const dailyTrips = await Sale.findAll({
+        where,
+        attributes: [
+          'trip_id',
+          [sequelize.fn('DATE', sequelize.col('sale_date')), 'date'],
+          [sequelize.fn('COUNT', sequelize.col('Sale.id')), 'sales'],
+          [sequelize.fn('SUM', sequelize.col('total_amount')), 'revenue']
+        ],
+        include: [{ model: Trip, as: 'trip', attributes: ['id', 'title'] }],
+        group: ['trip_id', 'trip.id', sequelize.fn('DATE', sequelize.col('sale_date'))],
+        order: [[sequelize.fn('DATE', sequelize.col('sale_date')), 'ASC']]
+      });
+      res.json({ success: true, data: { dailyTrips } });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async sellerProductivity(req, res, next) {
+    try {
+      const { start_date, end_date } = req.query;
+      const where = ReportController.buildCompanyFilter(req.user);
+      if (start_date && end_date) {
+        where.sale_date = { [Op.between]: [new Date(start_date), new Date(end_date)] };
+      }
+      const productivity = await Sale.findAll({
+        where,
+        attributes: [
+          'seller_id',
+          [sequelize.fn('COUNT', sequelize.col('Sale.id')), 'sales'],
+          [sequelize.fn('SUM', sequelize.col('total_amount')), 'revenue']
+        ],
+        include: [{ model: User, as: 'seller', attributes: ['id', 'firstName', 'lastName', 'email'] }],
+        group: ['seller_id', 'seller.id'],
+        order: [[sequelize.fn('SUM', sequelize.col('total_amount')), 'DESC']]
+      });
+      res.json({ success: true, data: { productivity } });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async financialReport(req, res, next) {
+    try {
+      const { start_date, end_date } = req.query;
+      const saleWhere = ReportController.buildCompanyFilter(req.user);
+      if (start_date && end_date) {
+        saleWhere.sale_date = { [Op.between]: [new Date(start_date), new Date(end_date)] };
+      }
+      const financial = await SalePayment.findAll({
+        include: [{ model: Sale, as: 'sale', where: saleWhere, attributes: [] }],
+        attributes: [
+          'payment_method',
+          [sequelize.fn('SUM', sequelize.col('amount')), 'total_amount'],
+          [sequelize.fn('COUNT', sequelize.col('SalePayment.id')), 'payments']
+        ],
+        group: ['payment_method'],
+        order: [[sequelize.fn('SUM', sequelize.col('amount')), 'DESC']]
+      });
+      res.json({ success: true, data: { financial } });
+    } catch (error) {
+      next(error);
+    }
+  }
+}
+
+module.exports = ReportController;

--- a/backend/src/routes/reports.js
+++ b/backend/src/routes/reports.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const router = express.Router();
+const ReportController = require('../controllers/ReportController');
+const { authenticate } = require('../middleware/auth');
+
+router.use(authenticate);
+
+router.get('/sales', ReportController.salesReport);
+router.get('/daily-trips', ReportController.dailyTrips);
+router.get('/seller-productivity', ReportController.sellerProductivity);
+router.get('/financial', ReportController.financialReport);
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -27,6 +27,7 @@ const activityRoutes = require('./routes/activities');
 const dashboardRoutes = require('./routes/dashboard');
 const settingsRoutes = require('./routes/settings');
 const notificationRoutes = require('./routes/notifications');
+const reportRoutes = require('./routes/reports');
 
 const app = express();
 const PORT = process.env.PORT || 3001;
@@ -79,6 +80,7 @@ app.use('/api/sales', saleRoutes);
 app.use('/api/accessories', accessoryRoutes);
 app.use('/api/activities', activityRoutes);
 app.use('/api/dashboard', dashboardRoutes);
+app.use('/api/reports', reportRoutes);
 app.use('/api/settings', settingsRoutes);
 app.use('/api/notifications', notificationRoutes);
 


### PR DESCRIPTION
## Summary
- implement `ReportController` with sales, trips, productivity and financial reports
- register new routes under `/api/reports`
- wire the router into the express server

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eeaa624e0832e86484ff6052a7f8b