### PR TITLE
Switch sales filters to delivery_date

### DIFF
--- a/backend/src/controllers/ReportController.js
+++ b/backend/src/controllers/ReportController.js
@@ -17,7 +17,7 @@ class ReportController {
       const { start_date, end_date } = req.query;
       const where = ReportController.buildCompanyFilter(req.user);
       if (start_date && end_date) {
-        where.sale_date = { [Op.between]: [new Date(start_date), new Date(end_date)] };
+        where.delivery_date = { [Op.between]: [new Date(start_date), new Date(end_date)] };
       }
       const sales = await Sale.findAll({
         where,
@@ -25,7 +25,7 @@ class ReportController {
           { model: Trip, as: 'trip', attributes: ['id', 'title'] },
           { model: User, as: 'seller', attributes: ['id', 'firstName', 'lastName'] }
         ],
-        order: [['sale_date', 'ASC']]
+        order: [['delivery_date', 'ASC']]
       });
       res.json({ success: true, data: { sales } });
     } catch (error) {
@@ -38,19 +38,19 @@ class ReportController {
       const { start_date, end_date } = req.query;
       const where = ReportController.buildCompanyFilter(req.user);
       if (start_date && end_date) {
-        where.sale_date = { [Op.between]: [new Date(start_date), new Date(end_date)] };
+        where.delivery_date = { [Op.between]: [new Date(start_date), new Date(end_date)] };
       }
       const dailyTrips = await Sale.findAll({
         where,
         attributes: [
           'trip_id',
-          [sequelize.fn('DATE', sequelize.col('sale_date')), 'date'],
+          [sequelize.fn('DATE', sequelize.col('delivery_date')), 'date'],
           [sequelize.fn('COUNT', sequelize.col('Sale.id')), 'sales'],
           [sequelize.fn('SUM', sequelize.col('total_amount')), 'revenue']
         ],
         include: [{ model: Trip, as: 'trip', attributes: ['id', 'title'] }],
-        group: ['trip_id', 'trip.id', sequelize.fn('DATE', sequelize.col('sale_date'))],
-        order: [[sequelize.fn('DATE', sequelize.col('sale_date')), 'ASC']]
+        group: ['trip_id', 'trip.id', sequelize.fn('DATE', sequelize.col('delivery_date'))],
+        order: [[sequelize.fn('DATE', sequelize.col('delivery_date')), 'ASC']]
       });
       res.json({ success: true, data: { dailyTrips } });
     } catch (error) {
@@ -63,7 +63,7 @@ class ReportController {
       const { start_date, end_date } = req.query;
       const where = ReportController.buildCompanyFilter(req.user);
       if (start_date && end_date) {
-        where.sale_date = { [Op.between]: [new Date(start_date), new Date(end_date)] };
+        where.delivery_date = { [Op.between]: [new Date(start_date), new Date(end_date)] };
       }
       const productivity = await Sale.findAll({
         where,
@@ -87,7 +87,7 @@ class ReportController {
       const { start_date, end_date } = req.query;
       const saleWhere = ReportController.buildCompanyFilter(req.user);
       if (start_date && end_date) {
-        saleWhere.sale_date = { [Op.between]: [new Date(start_date), new Date(end_date)] };
+        saleWhere.delivery_date = { [Op.between]: [new Date(start_date), new Date(end_date)] };
       }
       const financial = await SalePayment.findAll({
         include: [{ model: Sale, as: 'sale', where: saleWhere, attributes: [] }],

--- a/backend/src/controllers/SaleController.js
+++ b/backend/src/controllers/SaleController.js
@@ -30,7 +30,7 @@ class SaleController {
         start_date,
         end_date,
         search,
-        sort_by = 'sale_date',
+        sort_by = 'delivery_date',
         sort_order = 'DESC'
       } = req.query;
 
@@ -51,9 +51,9 @@ class SaleController {
       if (customer_id) where.customer_id = customer_id;
       if (trip_id) where.trip_id = trip_id;
 
-      // Filtro por período
+      // Filtro por período baseado na data de entrega
       if (start_date && end_date) {
-        where.sale_date = {
+        where.delivery_date = {
           [Op.between]: [new Date(start_date), new Date(end_date)]
         };
       }

--- a/backend/src/middleware/saleValidations.js
+++ b/backend/src/middleware/saleValidations.js
@@ -389,7 +389,7 @@ const listSalesValidation = [
 
   query('sort_by')
     .optional()
-    .isIn(['sale_date', 'total_amount', 'status', 'payment_status', 'created_at', 'updated_at'])
+    .isIn(['sale_date', 'delivery_date', 'total_amount', 'status', 'payment_status', 'created_at', 'updated_at'])
     .withMessage('Campo de ordenação inválido'),
 
   query('sort_order')


### PR DESCRIPTION
## Summary
- filter sales by `delivery_date` and sort by default by delivery date
- add `delivery_date` to allowed sort fields
- update reports to use `delivery_date` for range queries

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e58e490e0832ebf557f187eb3cb10